### PR TITLE
Sed cases branched off master

### DIFF
--- a/2d/sediment/bed_sediment/TimeSeriesPlot.py
+++ b/2d/sediment/bed_sediment/TimeSeriesPlot.py
@@ -1,0 +1,54 @@
+from proteus import StepControl
+#from scipy import *
+from pylab import *
+from numpy import *
+import collections as cll
+
+filename='pointGauge_pressure.txt'
+headerline = 0
+
+
+# Read header info 
+
+fid = open(filename,'r')
+prdata=loadtxt(fid,skiprows=headerline)
+fid.seek(0)
+D = fid.readlines()
+header = D[:headerline]
+n=len(D)
+
+a = array(zeros((int(n),5)))
+step = zeros(int(n),float)
+for i in range (int(n)):
+ a[i,:]=D[i].split()
+ step[i]=i
+
+a = array(a,dtype=float32)
+
+y = zeros(int(n),float)
+
+y[:] = a[:,2]
+
+
+
+
+
+
+#j=str(2)
+
+fig1 = figure(1)
+fig1.add_subplot(1,1,1)
+plot(step[:],y[:],"k",lw=2)
+
+##xlim(80,90)
+##ylim(-0.05,0.05)
+
+grid()
+#title('Surface elevation at $x=$' + str(probex[int(j)])+'m')
+title('Point gauge pressure evolution')
+xlabel('Step')
+ylabel('Pressure')
+
+show()
+savefig('plottrial.pdf')
+savefig('plottrial.png',dpi=100)

--- a/2d/sediment/bed_sediment/dissipation_n.py
+++ b/2d/sediment/bed_sediment/dissipation_n.py
@@ -1,0 +1,59 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import dissipation_p as physics
+from proteus import Context
+from proteus.mprans import Dissipation
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+triangleOptions = mesh.triangleOptions
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_cfl_controller
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = Dissipation.NumericalFlux
+conservativeFlux  = None
+subgridError      = Dissipation.SubgridError(coefficients=physics.coefficients,nd=ct.nd)
+shockCapturing    = Dissipation.ShockCapturing(physics.coefficients,ct.nd,shockCapturingFactor=ct.dissipation_shockCapturingFactor,
+                                         lag=ct.dissipation_lag_shockCapturing)
+
+fullNewtonFlag  = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+#printNonlinearSolverInfo = True
+matrix = SparseMatrix
+if not ct.useOldPETSc and not ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+else:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'dissipation_'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'rits'
+
+tolFac = 0.0
+linTolFac =0.0
+l_atol_res = 0.001*ct.dissipation_nl_atol_res
+nl_atol_res = ct.dissipation_nl_atol_res
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+

--- a/2d/sediment/bed_sediment/dissipation_p.py
+++ b/2d/sediment/bed_sediment/dissipation_p.py
@@ -1,0 +1,53 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import Dissipation
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = Dissipation.LevelModel
+
+dissipation_model_flag = 1
+if ct.useRANS >= 2:
+    dissipation_model_flag=2
+coefficients = Dissipation.Coefficients(V_model=ct.V_model,
+                                        ME_model=ct.EPS_model,
+                                        LS_model=ct.LS_model,
+                                        RD_model=ct.RD_model,
+                                        kappa_model=ct.K_model,
+                                        SED_model=ct.SED_model,
+                                        dissipation_model_flag=dissipation_model_flag+int(ct.movingDomain),#1 -- K-epsilon, 2 -- K-omega
+                                        useMetrics=useMetrics,
+                                        rho_0=rho_0,
+                                        nu_0=nu_0,
+                                        rho_1=rho_1,
+                                        nu_1=nu_1,
+                                        g=g,
+                                        c_mu=ct.opts.Cmu,sigma_e=ct.opts.sigma_e,
+                                        nd = ct.nd,
+                                        sc_uref=dissipation_sc_uref,
+                                        sc_beta=dissipation_sc_beta,
+                                        closure = ct.sedClosure )
+
+kInflow=ct.dissipationInflow
+
+dissipationInflow=ct.dissipationInflow
+
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].dissipation_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].dissipation_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {},
+                                   1: {1: lambda x, flag: domain.bc[flag].dissipation_diffusive.init_cython()},
+                                  }
+
+ 
+class ConstantIC:
+    def __init__(self,cval=0.0):
+        self.cval=cval
+    def uOfXT(self,x,t):
+        return self.cval
+
+initialConditions  = {0:ConstantIC(cval=dissipationInflow)}

--- a/2d/sediment/bed_sediment/eddy_viscosity_view_batch.py
+++ b/2d/sediment/bed_sediment/eddy_viscosity_view_batch.py
@@ -1,0 +1,7 @@
+from proteus import StepControl
+#0 is Navier-Stokes flow model
+simFlagsList[0]['storeQuantities']= ['simulationData',"q:'eddy_viscosity'"]
+simFlagsList[0]['storeTimes']     = ['All']
+#
+start
+quit

--- a/2d/sediment/bed_sediment/kappa_n.py
+++ b/2d/sediment/bed_sediment/kappa_n.py
@@ -1,0 +1,61 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import kappa_p as physics
+from proteus import Context
+from proteus.mprans import Kappa
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+triangleOptions = mesh.triangleOptions
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_cfl_controller
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = Kappa.NumericalFlux
+conservativeFlux  = None
+subgridError      = Kappa.SubgridError(coefficients=physics.coefficients,nd=ct.nd)
+shockCapturing    = Kappa.ShockCapturing(physics.coefficients,ct.nd,shockCapturingFactor=ct.kappa_shockCapturingFactor,
+                                         lag=ct.kappa_lag_shockCapturing)
+
+fullNewtonFlag  = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+#printNonlinearSolverInfo = True
+matrix = SparseMatrix
+if not ct.useOldPETSc and not ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+else:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'kappa_'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'rits'
+
+tolFac = 0.0
+linTolFac =0.0
+l_atol_res = 0.001*ct.kappa_nl_atol_res
+nl_atol_res = ct.kappa_nl_atol_res
+useEisenstatWalker = False
+
+maxNonlinearIts = 10
+maxLineSearches = 0
+
+auxiliaryVariables = ct.domain.auxiliaryVariables['kappa']
+

--- a/2d/sediment/bed_sediment/kappa_p.py
+++ b/2d/sediment/bed_sediment/kappa_p.py
@@ -1,0 +1,50 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import Kappa
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = Kappa.LevelModel
+
+dissipation_model_flag = 1
+if ct.useRANS >= 2:
+    dissipation_model_flag=2
+
+coefficients = Kappa.Coefficients(V_model=ct.V_model,
+                                  ME_model=ct.K_model,
+                                  LS_model=ct.LS_model,
+                                  RD_model=ct.RD_model,
+                                  dissipation_model=ct.EPS_model,
+                                  SED_model=ct.SED_model,
+                                  dissipation_model_flag=dissipation_model_flag+int(ct.movingDomain),#1 -- K-epsilon, 2 -- K-omega
+                                  useMetrics=useMetrics,
+                                  rho_0=rho_0,nu_0=nu_0,
+                                  rho_1=rho_1,nu_1=nu_1,
+                                  g=g,
+                                  nd = ct.nd,
+                                  c_mu=ct.opts.Cmu,sigma_k=ct.opts.sigma_k, 
+                                  sc_uref=kappa_sc_uref,
+                                  sc_beta=kappa_sc_beta,
+                                  closure = ct.sedClosure)
+
+kInflow=ct.kInflow
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].k_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].k_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {},
+                                   1: {1: lambda x, flag: domain.bc[flag].k_diffusive.init_cython()},
+                                  }
+
+
+class ConstantIC:
+    def __init__(self,cval=0.0):
+        self.cval=cval
+    def uOfXT(self,x,t):
+        return self.cval
+
+   
+initialConditions  = {0:ConstantIC(cval=kInflow)}

--- a/2d/sediment/bed_sediment/ls_consrv_n.py
+++ b/2d/sediment/bed_sediment/ls_consrv_n.py
@@ -1,0 +1,78 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools,
+                     NumericalFlux)
+import ls_consrv_p as physics
+from proteus import Context
+from proteus.mprans.MCorr3P import DummyNewton
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+#time stepping
+runCFL = ct.runCFL
+timeIntegrator  = TimeIntegration.ForwardIntegrator
+timeIntegration = TimeIntegration.NoIntegration
+
+#mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0:ct.basis}
+
+subgridError      = None
+massLumping       = False
+numericalFluxType = ct.DoNothing
+conservativeFlux  = None
+shockCapturing    = None
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+#multilevelNonlinearSolver = DummyNewton
+#levelNonlinearSolver      = DummyNewton
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'mcorr_'
+nonlinearSolverConvergenceTest  = 'rits'
+levelNonlinearSolverConvergenceTest  = 'rits'
+linearSolverConvergenceTest  = 'r-true'
+
+tolFac = 0.0
+linTolFac = 0.01
+l_atol_res = 0.01*ct.mcorr_nl_atol_res
+nl_atol_res = ct.mcorr_nl_atol_res
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0

--- a/2d/sediment/bed_sediment/ls_consrv_p.py
+++ b/2d/sediment/bed_sediment/ls_consrv_p.py
@@ -1,0 +1,40 @@
+from proteus import StepControl
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import MCorr3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+
+LevelModelType = MCorr3P.LevelModel
+
+coefficients = MCorr3P.Coefficients(LS_model=ct.LS_model,
+                                    V_model=ct.V_model,
+                                    ME_model=ct.MCORR_model,
+                                    VOF_model=ct.VOF_model,
+                                    VOS_model=ct.VOS_model,
+                                    applyCorrection=ct.applyCorrection,
+                                    nd=nd,
+                                    checkMass=False,
+                                    useMetrics=ct.useMetrics,
+                                    epsFactHeaviside=ct.epsFact_consrv_heaviside,
+                                    epsFactDirac=ct.epsFact_consrv_dirac,
+                                    epsFactDiffusion=ct.epsFact_consrv_diffusion)
+
+class zero_phi:
+    def __init__(self):
+        pass
+    def uOfX(self,X):
+        return 0.0
+    def uOfXT(self,X,t):
+        return 0.0
+
+initialConditions  = {0:zero_phi()}

--- a/2d/sediment/bed_sediment/ls_n.py
+++ b/2d/sediment/bed_sediment/ls_n.py
@@ -1,0 +1,78 @@
+from proteus import StepControl
+from proteus.default_n import *
+import ls_p as physics
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+from proteus.mprans import NCLS3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+coefficients = physics.coefficients
+
+# time stepping
+runCFL = ct.runCFL
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_controller
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0: ct.basis}
+
+massLumping       = False
+conservativeFlux  = None
+numericalFluxType = NCLS3P.NumericalFlux
+subgridError      = NCLS3P.SubgridError(coefficients,nd)
+shockCapturing    = NCLS3P.ShockCapturing(coefficients,nd,shockCapturingFactor=ct.ls_shockCapturingFactor,lag=ct.ls_lag_shockCapturing)
+
+fullNewtonFlag  = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'ncls_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'r-true'
+
+tolFac = 0.0
+nl_atol_res = ct.ls_nl_atol_res
+linTolFac = 0.0
+l_atol_res = 0.1*ct.ls_nl_atol_res
+
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+
+auxiliaryVariables = ct.domain.auxiliaryVariables['ls']

--- a/2d/sediment/bed_sediment/ls_p.py
+++ b/2d/sediment/bed_sediment/ls_p.py
@@ -1,0 +1,39 @@
+from proteus import StepControl
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import NCLS3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+
+LevelModelType = NCLS3P.LevelModel
+
+coefficients = NCLS3P.Coefficients(V_model=ct.V_model,
+                                   RD_model=ct.RD_model,
+                                   ME_model=ct.LS_model,
+                                   checkMass=False,
+                                   useMetrics=ct.useMetrics,
+                                   epsFact=ct.epsFact_consrv_heaviside,
+                                   sc_uref=ct.ls_sc_uref,
+                                   sc_beta=ct.ls_sc_beta,
+                                   movingDomain=ct.movingDomain)
+
+dirichletConditions = {0: lambda x, flag: None}
+
+advectiveFluxBoundaryConditions = {}
+
+diffusiveFluxBoundaryConditions = {0: {}}
+
+class PHI_IC:
+    def uOfXT(self, x, t):
+        return x[nd-1] - ct.waterLevel
+
+initialConditions = {0: PHI_IC()}

--- a/2d/sediment/bed_sediment/pressureInitial_n.py
+++ b/2d/sediment/bed_sediment/pressureInitial_n.py
@@ -1,0 +1,54 @@
+from proteus import *
+from proteus.default_n import *
+from pressureInitial_p import *
+
+
+mesh = domain.MeshOptions
+triangleOptions = triangleOptions
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+
+femSpaces = {0:ct.pbasis}
+
+stepController=FixedStep
+
+#numericalFluxType = NumericalFlux.ConstantAdvection_Diffusion_SIPG_exterior #weak boundary conditions (upwind ?)
+matrix = LinearAlgebraTools.SparseMatrix
+
+#linearSmoother    = LinearSolvers.NavierStokesPressureCorrection # pure neumann laplacian solver
+#multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+#levelLinearSolver = LinearSolvers.KSP_petsc4py
+#linearSmoother    = None
+#multilevelLinearSolver = LinearSolvers.LU
+#levelLinearSolver      = LinearSolvers.LU
+numericalFluxType = NumericalFlux.ConstantAdvection_exterior
+#numericalFluxType = NumericalFlux
+
+linear_solver_options_prefix = 'pinit_'
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+else:
+    multilevelLinearSolver = KSP_petsc4py
+    levelLinearSolver      = KSP_petsc4py
+    parallelPartitioningType    = parallelPartitioningType
+    nLayersOfOverlapForParallel = nLayersOfOverlapForParallel
+    nonlinearSmoother = None
+    linearSmoother    = None
+
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+#linear solve rtolerance
+
+linTolFac = 0.0
+l_atol_res = 0.01*ct.phi_nl_atol_res
+tolFac = 0.0
+nl_atol_res = ct.phi_nl_atol_res
+nonlinearSolverConvergenceTest = 'r'
+levelNonlinearSolverConvergenceTest = 'r'
+linearSolverConvergenceTest             = 'r-true'
+maxLineSearches=0
+periodicDirichletConditions=None
+
+conservativeFlux=None

--- a/2d/sediment/bed_sediment/pressureInitial_p.py
+++ b/2d/sediment/bed_sediment/pressureInitial_p.py
@@ -1,0 +1,43 @@
+from math import *
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import PresInit
+from proteus import Context
+from tank import *
+
+ct = Context.get()
+name = "pressureInitial"
+
+coefficients=PresInit.Coefficients(nd=nd,
+                                   modelIndex=ct.PI_model,
+                                   fluidModelIndex=ct.V_model,
+                                   pressureModelIndex=ct.P_model)
+
+#pressure increment should be zero on any pressure dirichlet boundaries
+
+#the advectiveFlux should be zero on any no-flow  boundaries
+
+
+class getIBC_pInit:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+class PerturbedSurface_p:
+    def __init__(self,waterLevel):
+        self.waterLevel=waterLevel
+    def uOfXT(self,x,t):
+        self.vos = ct.vos_function(x)
+        self.rho_a = rho_1#(1.-self.vos)*rho_1 + (self.vos)*ct.rho_s
+        self.rho_w = rho_0#(1.-self.vos)*rho_0 + (self.vos)*ct.rho_s
+        if signedDistance(x) < 0:
+            return -(L[1] - self.waterLevel)*self.rho_a*g[1] - (self.waterLevel - x[1])*self.rho_w*g[1]
+        else:
+            return -(L[1] - x[1])*self.rho_a*g[1]
+
+initialConditions = {0:PerturbedSurface_p(waterLine_z)} #getIBC_pInit()}
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].pInit_dirichlet.init_cython()}
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].pInit_advective.init_cython()}
+diffusiveFluxBoundaryConditions = {0:{0: lambda x, flag: domain.bc[flag].pInit_diffusive.init_cython()}}

--- a/2d/sediment/bed_sediment/pressure_n.py
+++ b/2d/sediment/bed_sediment/pressure_n.py
@@ -1,0 +1,53 @@
+from proteus import *
+from proteus.default_n import *
+from pressure_p import *
+
+
+mesh = domain.MeshOptions
+triangleOptions = triangleOptions
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+
+femSpaces = {0:ct.pbasis}
+
+
+# stepController  = StepControl.Min_dt_cfl_controller
+# runCFL= 0.99
+# runCFL= 0.5
+
+stepController=FixedStep
+
+#matrix type
+numericalFluxType = NumericalFlux.ConstantAdvection_exterior
+#numericalFluxType = NumericalFlux
+matrix = LinearAlgebraTools.SparseMatrix
+
+linear_solver_options_prefix = 'pressure_'
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+else:
+    multilevelLinearSolver = KSP_petsc4py
+    levelLinearSolver      = KSP_petsc4py
+    parallelPartitioningType    = parallelPartitioningType
+    nLayersOfOverlapForParallel = nLayersOfOverlapForParallel
+    nonlinearSmoother = None
+    linearSmoother    = None
+
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+#linear solve rtolerance
+
+linTolFac = 0.0
+l_atol_res = 0.1*ct.pressure_nl_atol_res
+tolFac = 0.0
+nl_atol_res = ct.pressure_nl_atol_res
+maxLineSearches = 0
+nonlinearSolverConvergenceTest      = 'r'
+levelNonlinearSolverConvergenceTest = 'r'
+linearSolverConvergenceTest         = 'r-true'
+
+periodicDirichletConditions=None
+
+conservativeFlux=None

--- a/2d/sediment/bed_sediment/pressure_p.py
+++ b/2d/sediment/bed_sediment/pressure_p.py
@@ -1,0 +1,34 @@
+from math import *
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import Pres
+from proteus import Context
+from tank import *
+
+ct = Context.get()
+name = "pressure"
+
+LevelModelType = Pres.LevelModel
+
+coefficients=Pres.Coefficients(modelIndex=ct.P_model,
+                               fluidModelIndex=ct.V_model,
+                               pressureIncrementModelIndex=ct.DP_model,
+                               useRotationalForm=True)
+
+
+class getIBC_p:
+    def __init__(self,waterLevel):
+        self.waterLevel=waterLevel
+    def uOfXT(self,x,t):
+        self.vos = ct.vos_function(x)
+        self.rho_a = rho_1#(1.-self.vos)*rho_1 + (self.vos)*ct.rho_s
+        self.rho_w = rho_0#(1.-self.vos)*rho_0 + (self.vos)*ct.rho_s
+        if signedDistance(x) < 0:
+            return -(L[1] - self.waterLevel)*self.rho_a*g[1] - (self.waterLevel - x[1])*self.rho_w*g[1]
+        else:
+            return -(L[1] - x[1])*self.rho_a*g[1]
+
+initialConditions = {0:getIBC_p(waterLine_z)}
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].p_dirichlet.init_cython() } # pressure bc are explicitly set
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].pInit_advective.init_cython()}

--- a/2d/sediment/bed_sediment/pressureincrement_n.py
+++ b/2d/sediment/bed_sediment/pressureincrement_n.py
@@ -1,0 +1,56 @@
+from proteus import *
+from proteus.default_n import *
+from pressureincrement_p import *
+
+mesh = domain.MeshOptions
+triangleOptions = triangleOptions
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+
+femSpaces = {0:pbasis}
+
+stepController=FixedStep
+
+#numericalFluxType = PresInc.NumericalFlux
+numericalFluxType = NumericalFlux.ConstantAdvection_exterior
+matrix = LinearAlgebraTools.SparseMatrix
+
+#if openTop:
+#    linearSmoother    = None
+#    multilevelLinearSolver = LinearSolvers.LU
+#    levelLinearSolver      = LinearSolvers.LU
+#else:
+#    linearSmoother         = LinearSolvers.NavierStokesPressureCorrection # pure neumann laplacian solver
+#    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+#    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+linear_solver_options_prefix = 'phi_'
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+else:
+    multilevelLinearSolver = KSP_petsc4py
+    levelLinearSolver      = KSP_petsc4py
+    parallelPartitioningType    = parallelPartitioningType
+    nLayersOfOverlapForParallel = nLayersOfOverlapForParallel
+    nonlinearSmoother = None
+    linearSmoother    = None
+
+
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+#linear solve rtolerance
+
+linTolFac = 0.0
+l_atol_res = 0.01*phi_nl_atol_res
+tolFac = 0.0
+nl_atol_res = phi_nl_atol_res
+nonlinearSolverConvergenceTest = 'r'
+levelNonlinearSolverConvergenceTest = 'r'
+linearSolverConvergenceTest             = 'r-true'
+maxLineSearches=0
+periodicDirichletConditions=None
+
+conservativeFlux = {0:'point-eval'} #'point-eval','pwl-bdm-opt'
+#conservativeFlux=None

--- a/2d/sediment/bed_sediment/pressureincrement_p.py
+++ b/2d/sediment/bed_sediment/pressureincrement_p.py
@@ -1,0 +1,50 @@
+from math import *
+from proteus import *
+from proteus.default_p import *
+from tank import *
+import tank_so
+from proteus.mprans import PresInc
+from proteus import Context
+
+ct = Context.get()
+
+
+#domain = ctx.domain
+#nd = ctx.nd
+name = "pressureincrement"
+
+LevelModelType = PresInc.LevelModel
+#from ProjectionScheme import PressureIncrement
+#coefficients=PressureIncrement(rho_f_min = rho_1,
+#                               rho_s_min = rho_s,
+#                               nd = nd,
+#                               modelIndex=PINC_model,
+#                               fluidModelIndex=V_model)
+from proteus.mprans import PresInc
+coefficients=PresInc.Coefficients(rho_f_min = (1.0-1.0e-8)*rho_1,
+                                  rho_s_min = (1.0-1.0e-8)*rho_s,
+                                  nd = nd,
+                                  modelIndex= ct.DP_model,
+                                  fluidModelIndex= ct.V_model,
+                                  sedModelIndex= ct.SED_model,
+                                  VOF_model= ct.VOF_model,
+                                  VOS_model= ct.VOS_model,
+                                  fixNullSpace=fixNullSpace_PresInc, 
+                                  INTEGRATE_BY_PARTS_DIV_U=ct.INTEGRATE_BY_PARTS_DIV_U_PresInc)
+
+
+#pressure increment should be zero on any pressure dirichlet boundaries
+
+#the advectiveFlux should be zero on any no-flow  boundaries
+
+class getIBC_phi:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+initialConditions = {0:getIBC_phi()}
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].pInc_dirichlet.init_cython()}
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].pInc_advective.init_cython()}
+diffusiveFluxBoundaryConditions = {0:{0: lambda x, flag: domain.bc[flag].pInc_diffusive.init_cython()}}

--- a/2d/sediment/bed_sediment/redist_n.py
+++ b/2d/sediment/bed_sediment/redist_n.py
@@ -1,0 +1,95 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools,
+                     NumericalFlux)
+from proteus.mprans import RDLS3P
+import redist_p as physics
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+# time stepping
+runCFL = ct.runCFL
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0: ct.basis}
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+massLumping       = False
+numericalFluxType = NumericalFlux.DoNothing
+conservativeFlux  = None
+subgridError      = RDLS3P.SubgridError(physics.coefficients,nd)
+shockCapturing    = RDLS3P.ShockCapturing(physics.coefficients,nd,shockCapturingFactor=ct.rd_shockCapturingFactor,lag=ct.rd_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver  = NonlinearSolvers.Newton
+levelNonlinearSolver       = NonlinearSolvers.Newton
+
+nonlinearSmoother = NonlinearSolvers.NLGaussSeidel
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+if ct.redist_Newton:
+    timeIntegration = NoIntegration
+    stepController = ct.Newton_controller
+    maxNonlinearIts = 50
+    maxLineSearches = 0
+    nonlinearSolverConvergenceTest = 'rits'
+    levelNonlinearSolverConvergenceTest = 'rits'
+    linearSolverConvergenceTest = 'r-true'
+    useEisenstatWalker = False
+else:
+    timeIntegration = BackwardEuler_cfl
+    stepController = RDLS3P.PsiTC
+    runCFL=2.0
+    psitc['nStepsForce']=3
+    psitc['nStepsMax']=50
+    psitc['reduceRatio']=10.0
+    psitc['startRatio']=1.0
+    rtol_res[0] = 0.0
+    atol_res[0] = rd_nl_atol_res
+    useEisenstatWalker = False#True
+    maxNonlinearIts = 1
+    maxLineSearches = 0
+    nonlinearSolverConvergenceTest = 'rits'
+    levelNonlinearSolverConvergenceTest = 'rits'
+    linearSolverConvergenceTest = 'r-true'
+
+linear_solver_options_prefix = 'rdls_'
+
+tolFac = 0.0
+nl_atol_res = ct.rd_nl_atol_res
+linTolFac = 0.01
+l_atol_res = 0.01*ct.rd_nl_atol_res
+useEisenstatWalker = False#True

--- a/2d/sediment/bed_sediment/redist_p.py
+++ b/2d/sediment/bed_sediment/redist_p.py
@@ -1,0 +1,46 @@
+from proteus import StepControl
+from proteus import *
+from proteus.default_p import *
+from math import *
+from proteus.mprans import RDLS3P
+from proteus import Context
+
+"""
+The redistancing equation in the sloshbox test problem.
+"""
+
+ct = Context.get()
+domain = ct.domain
+nd = domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+
+LevelModelType = RDLS3P.LevelModel
+
+
+
+coefficients = RDLS3P.Coefficients(applyRedistancing=ct.applyRedistancing,
+                                   epsFact=ct.epsFact_redistance,
+                                   nModelId=ct.LS_model,
+                                   rdModelId=ct.RD_model,
+                                   useMetrics=ct.useMetrics,
+                                   backgroundDiffusionFactor=ct.backgroundDiffusionFactor)
+
+def getDBC_rd(x,flag):
+    pass
+
+dirichletConditions     = {0:getDBC_rd}
+weakDirichletConditions = {0:RDLS3P.setZeroLSweakDirichletBCsSimple}
+
+advectiveFluxBoundaryConditions =  {}
+diffusiveFluxBoundaryConditions = {0:{}}
+
+class PHI_IC:
+    def uOfXT(self, x, t):
+        return x[nd-1] - ct.waterLevel
+
+initialConditions  = {0: PHI_IC()}

--- a/2d/sediment/bed_sediment/run.sh
+++ b/2d/sediment/bed_sediment/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir $1
+cp tank.py $1/tank.py
+mpirun -np 4 parun -l 5 -v tank_so.py -O ../../../inputTemplates/petsc.options.asm -D $1

--- a/2d/sediment/bed_sediment/tank.py
+++ b/2d/sediment/bed_sediment/tank.py
@@ -1,0 +1,466 @@
+from proteus import StepControl
+from math import *
+import proteus.MeshTools
+from proteus import Domain, Context
+from proteus.default_n import *
+from proteus.Profiling import logEvent
+from proteus.mprans import SpatialTools as st
+from proteus import Gauges as ga
+from proteus import WaveTools as wt
+from proteus.mprans.SedClosure import  HsuSedStress
+
+
+opts=Context.Options([
+    # Geometry and sed parameters
+    ("waterLine_x", 10.00, "Width of free surface from left to right"),
+    ("waterLine_z", 2., "Heigth of free surface above bottom"),
+    ("sediment_level", 1., "Height of the sediment column"),
+    ("sediment_bottom", -20., "Height of the sediment column"),
+    ("Lx", 1.50, "Length of the numerical domain"),
+    ("Ly", 3., "Heigth of the numerical domain"),
+    ("dtout", 0.05, "Time interval for output"),
+    #fluid parameters
+    ("rho_0", 998.2, "water density"),
+    ("rho_1", 1.205, "air density"),
+    ("nu_0", 1e-6, "water kin viscosity"),
+    ("nu_1", 1.5e-5, "air kin viscosity"),
+    ('g',np.array([0.0, -9.8, 0.0]),'Gravitational acceleration'),    
+    # sediment parameters
+    ('cSed', 0.55,'Initial sediment concentration'),
+    ('rho_s',2600 ,'sediment material density'),
+    ('alphaSed', 150.,'laminar drag coefficient'),
+    ('betaSed', 1.72,'turbulent drag coefficient'),
+    ('grain',0.0025, 'Grain size'),
+    ('packFraction',0.2,'threshold for loose / packed sediment'),
+    ('packMargin',0.01,'transition margin for loose / packed sediment'),
+    ('maxFraction',0.635,'fraction at max  sediment packing'),
+    ('frFraction',0.57,'fraction where contact stresses kick in'),
+    ('sigmaC',0.57,'Schmidt coefficient for turbulent diffusion'),
+    ('C3e',1.2,'Dissipation coefficient '),
+    ('C4e',1.2,'Dissipation coefficient'),
+    ('eR', 0.8, 'Collision stress coefficient (module not functional)'),
+    ('fContact', 0.05,'Contact stress coefficient'),
+    ('mContact', 3.0,'Contact stress coefficient'),
+    ('nContact', 5.0,'Contact stress coefficient'),
+    ('angFriction', pi/6., 'Angle of friction'),
+    ('vos_limiter', 0.6, 'Weak limiter for vos'),
+    ('mu_fr_limiter', 1e-3,'Hard limiter for contact stress friction coeff'),
+     # numerical options
+    ("refinement", 25.,"L[0]/refinement"),
+    ("sedimentDynamics", True, "Enable sediment dynamics module"),
+    ("cfl", 0.25 ,"Target cfl"),
+    ("duration", 5.0 ,"Duration of the simulation"),
+    ("PSTAB", 1.0, "Affects subgrid error"),
+    ("res", 1.0e-8, "Residual tolerance"),
+    ("epsFact_density", 3.0, "Control width of water/air transition zone"),
+    ("epsFact_consrv_diffusion", 1.0, "Affects smoothing diffusion in mass conservation"),
+    ("useRANS", 0, "Switch ON turbulence models: 0-None, 1-K-Epsilon, 2-K-Omega1998, 3-K-Omega1988"),
+    ("vos_SC",0.9,"vos shock capturing"),
+    # ns_closure: 1-classic smagorinsky, 2-dynamic smagorinsky, 3-k-epsilon, 4-k-omega
+    ("sigma_k", 1.0, "sigma_k coefficient for the turbulence model"),
+    ("sigma_e", 1.0, "sigma_e coefficient for the turbulence model"),
+    ("Cmu", 0.09, "Cmu coefficient for the turbulence model"),
+    ])
+
+# SO Models
+
+VOS_model = 0
+VOF_model = 1
+LS_model = 2
+RD_model = 3
+MCORR_model =4
+SED_model =5
+V_model =6
+DP_model = 7
+P_model = 8
+
+
+if opts.useRANS:
+    K_model = 9
+    EPS_model = 10
+    PI_model = 11
+else:
+    K_model = None
+    EPS_model = None   
+    PI_model = 9
+
+# Domain dimensions
+
+nd = 2
+
+# ----- Sediment stress ----- #
+
+sedClosure = HsuSedStress(aDarcy =  opts.alphaSed,
+                          betaForch =  opts.betaSed,
+                          grain =  opts.grain,
+                          packFraction =  opts.packFraction,
+                          packMargin =  opts.packMargin,
+                          maxFraction =  opts.maxFraction,
+                          frFraction =  opts.frFraction,
+                          sigmaC =  opts.sigmaC,
+                          C3e =  opts.C3e,
+                          C4e =  opts.C4e,
+                          eR =  opts.eR,
+                          fContact =  opts.fContact,
+                          mContact =  opts.mContact,
+                          nContact =  opts.nContact,
+                          angFriction =  opts.angFriction,
+                          vos_limiter = opts.vos_limiter,
+                          mu_fr_limiter = opts.mu_fr_limiter,
+                          )
+
+# ----- DOMAIN ----- #
+
+domain = Domain.PlanarStraightLineGraphDomain()
+
+
+# ----- Phisical constants ----- #
+  
+# Water
+rho_0 = opts.rho_0
+nu_0 = opts.nu_0
+
+# Air
+rho_1 = opts.rho_1
+nu_1 = opts.nu_1
+
+# Sediment
+rho_s = opts.rho_s
+nu_s = 1000000
+dragAlpha = 0.0
+
+# Surface tension
+sigma_01 = 0.0
+
+# Gravity
+g = opts.g
+gamma_0 = abs(g[1])*rho_0
+
+# Initial condition
+waterLine_x = opts.waterLine_x
+waterLine_z = opts.waterLine_z
+sediment_level = opts.sediment_level
+sediment_bottom = opts.sediment_bottom
+waterLevel = waterLine_z
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Domain and mesh
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+L = (opts.Lx, opts.Ly)
+he = L[0]/opts.refinement
+dim = dimx, dimy = L
+coords = [ dimx/2., dimy/2. ]
+
+boundaryOrientations = {'y-': np.array([0., -1.,0.]),
+                        'x+': np.array([+1, 0.,0.]),
+                        'y+': np.array([0., +1.,0.]),
+                        'x-': np.array([-1., 0.,0.]),
+                        'sponge': None,
+                           }
+boundaryTags = {'y-': 1,
+                    'x+': 2,
+                    'y+': 3,
+                    'x-': 4,
+                    'sponge': 5,
+                       }
+
+tank = st.Rectangle(domain, dim=dim, coords=coords)
+
+#############################################################################################################################################################################################################################################################################################################################################################################################
+# ----- BOUNDARY CONDITIONS ----- #
+#############################################################################################################################################################################################################################################################################################################################################################################################
+
+tank.BC['y-'].setFreeSlip()
+tank.BC['y+'].setAtmosphere(orientation=np.array([0., +1.,0.]))
+tank.BC['x-'].setFreeSlip()
+tank.BC['x+'].setFreeSlip()
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Turbulence
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+
+if opts.useRANS:
+    kInflow = 1e-6
+    dissipationInflow = 1e-6
+    tank.BC['x-'].setTurbulentZeroGradient()
+    tank.BC['x+'].setTurbulentZeroGradient()
+    tank.BC['y-'].setTurbulentZeroGradient()
+    tank.BC['y+'].setTurbulentZeroGradient()
+
+
+######################################################################################################################################################################################################################
+# Gauges and probes #
+######################################################################################################################################################################################################################
+
+T=opts.duration
+PG = []
+gauge_dy=0.01
+tank_dim_y=dimy
+nprobes=int(tank_dim_y/gauge_dy)+1
+probes=np.linspace(0., tank_dim_y, nprobes)
+for i in probes:
+    PG.append((dimx/2., i, 0.),)
+v_output = ga.PointGauges(gauges=((('u',), PG),
+                                  (('v',), PG),),
+                          activeTime = (0., T),
+                          sampleRate=0.,
+                          fileName='fluidVelocityGauges.csv')
+vs_output = ga.PointGauges(gauges=((('us',),PG), 
+                                   (('vs',),PG),),
+                          activeTime = (0., T),
+                          sampleRate=0.,
+                          fileName='solidVelocityGauges.csv')
+vos_output = ga.PointGauges(gauges=((('vos',),PG),),
+                          activeTime = (0., T),
+                          sampleRate=0.,
+                          fileName='solidFractionGauges.csv')
+
+######################################################################################################################################################################################################################
+# Numerical Options and other parameters #
+######################################################################################################################################################################################################################
+ 
+domain.MeshOptions.he = he
+
+from math import *
+from proteus import MeshTools, AuxiliaryVariables
+import numpy
+import proteus.MeshTools
+from proteus import Domain
+from proteus.Profiling import logEvent
+from proteus.default_n import *
+from proteus.ctransportCoefficients import smoothedHeaviside
+from proteus.ctransportCoefficients import smoothedHeaviside_integral
+
+st.assembleDomain(domain)
+
+
+#----------------------------------------------------
+# Time stepping and velocity
+#----------------------------------------------------
+
+T=opts.duration
+weak_bc_penalty_constant = 10.0/nu_0 #100
+dt_fixed = opts.dtout
+dt_init = min(0.1*dt_fixed,0.001)
+nDTout= int(round(T/dt_fixed))
+runCFL = opts.cfl
+
+sedimentDynamics=opts.sedimentDynamics
+
+#----------------------------------------------------
+#  Discretization -- input options
+#----------------------------------------------------
+
+genMesh = True
+movingDomain = False
+applyRedistancing = True
+useOldPETSc = False
+useSuperlu = False
+timeDiscretization = 'be'#'vbdf'#'vbdf'  # 'vbdf', 'be', 'flcbdf'
+spaceOrder = 1
+pspaceOrder = 1
+useHex = False
+useRBLES = 0.0
+useMetrics = 1.0
+applyCorrection = True
+useVF = 1.0
+useOnlyVF = False
+useRANS = opts.useRANS  # 0 -- None
+                        # 1 -- K-Epsilon
+                        # 2 -- K-Omega
+
+
+KILL_PRESSURE_TERM = False
+fixNullSpace_PresInc = True
+INTEGRATE_BY_PARTS_DIV_U_PresInc = True
+CORRECT_VELOCITY = True
+STABILIZATION_TYPE = 0 #0: SUPG, 1: EV via weak residual, 2: EV via strong residual
+
+# Input checks
+if spaceOrder not in [1, 2]:
+    print "INVALID: spaceOrder" + spaceOrder
+    sys.exit()
+
+if useRBLES not in [0.0, 1.0]:
+    print "INVALID: useRBLES" + useRBLES
+    sys.exit()
+
+if useMetrics not in [0.0, 1.0]:
+    print "INVALID: useMetrics"
+    sys.exit()
+
+#  Discretization
+nd = tank.nd
+
+if spaceOrder == 1:
+    hFactor = 1.0
+    if useHex:
+        basis = C0_AffineLinearOnCubeWithNodalBasis
+        elementQuadrature = CubeGaussQuadrature(nd, 2)
+        elementBoundaryQuadrature = CubeGaussQuadrature(nd - 1, 2)
+    else:
+        basis = C0_AffineLinearOnSimplexWithNodalBasis
+        elementQuadrature = SimplexGaussQuadrature(nd, 3)
+        elementBoundaryQuadrature = SimplexGaussQuadrature(nd - 1, 3)
+elif spaceOrder == 2:
+    hFactor = 0.5
+    if useHex:
+        basis = C0_AffineLagrangeOnCubeWithNodalBasis
+        elementQuadrature = CubeGaussQuadrature(nd, 4)
+        elementBoundaryQuadrature = CubeGaussQuadrature(nd - 1, 4)
+    else:
+        basis = C0_AffineQuadraticOnSimplexWithNodalBasis
+        elementQuadrature = SimplexGaussQuadrature(nd, 4)
+        elementBoundaryQuadrature = SimplexGaussQuadrature(nd - 1, 4)
+
+if pspaceOrder == 1:
+    if useHex:
+        pbasis = C0_AffineLinearOnCubeWithNodalBasis
+    else:
+        pbasis = C0_AffineLinearOnSimplexWithNodalBasis
+elif pspaceOrder == 2:
+    if useHex:
+        pbasis = C0_AffineLagrangeOnCubeWithNodalBasis
+    else:
+        pbasis = C0_AffineQuadraticOnSimplexWithNodalBasis
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Numerical parameters
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+ns_forceStrongDirichlet = False
+ns_sed_forceStrongDirichlet = False
+backgroundDiffusionFactor=0.01
+
+if useMetrics:
+    ns_shockCapturingFactor = 0.5
+    ns_lag_shockCapturing = True
+    ns_lag_subgridError = True
+    ns_sed_shockCapturingFactor = 0.5
+    ns_sed_lag_shockCapturing = True
+    ns_sed_lag_subgridError = True
+    ls_shockCapturingFactor = 0.5
+    ls_lag_shockCapturing = True
+    ls_sc_uref = 1.0
+    ls_sc_beta = 1.0
+    vof_shockCapturingFactor = 0.5
+    vof_lag_shockCapturing = True
+    vof_sc_uref = 1.0
+    vof_sc_beta = 1.0
+    vos_shockCapturingFactor =  opts.vos_SC # <------------------------------------- 
+    vos_lag_shockCapturing = True
+    vos_sc_uref = 1.0
+    vos_sc_beta = 1.0
+    rd_shockCapturingFactor = 0.5
+    rd_lag_shockCapturing = False
+    epsFact_vos =opts.epsFact_density
+    epsFact_density = opts.epsFact_density # 1.5
+    epsFact_viscosity = epsFact_curvature = epsFact_vof = epsFact_consrv_heaviside = epsFact_consrv_dirac = epsFact_density
+    epsFact_redistance = 0.33
+    epsFact_consrv_diffusion = opts.epsFact_consrv_diffusion # 0.1
+    redist_Newton = True
+    kappa_shockCapturingFactor = 0.25
+    kappa_lag_shockCapturing = True  #False
+    kappa_sc_uref = 1.0
+    kappa_sc_beta = 1.0
+    dissipation_shockCapturingFactor = 0.25
+    dissipation_lag_shockCapturing = True  #False
+    dissipation_sc_uref = 1.0
+    dissipation_sc_beta = 1.0
+else:
+    ns_shockCapturingFactor = 0.9
+    ns_lag_shockCapturing = True
+    ns_lag_subgridError = True
+    ns_sed_shockCapturingFactor = 0.9
+    ns_sed_lag_shockCapturing = True
+    ns_sed_lag_subgridError = True
+    ls_shockCapturingFactor = 0.9
+    ls_lag_shockCapturing = True
+    ls_sc_uref = 1.0
+    ls_sc_beta = 1.0
+    vof_shockCapturingFactor = 0.9
+    vof_lag_shockCapturing = True
+    vof_sc_uref = 1.0
+    vof_sc_beta = 1.0
+    vos_shockCapturingFactor = 5.
+    vos_lag_shockCapturing = True
+    vos_sc_uref = 1.0
+    vos_sc_beta = 1.0
+    rd_shockCapturingFactor = 0.9
+    rd_lag_shockCapturing = False
+    epsFact_density = opts.epsFact_density # 1.5
+    epsFact_viscosity = epsFact_curvature = epsFact_vof = epsFact_vos = epsFact_consrv_heaviside = epsFact_consrv_dirac = epsFact_density
+    epsFact_redistance = 0.33
+    epsFact_consrv_diffusion = opts.epsFact_consrv_diffusion # 1.0
+    redist_Newton = False
+    kappa_shockCapturingFactor = 0.9
+    kappa_lag_shockCapturing = True  #False
+    kappa_sc_uref = 1.0
+    kappa_sc_beta = 1.0
+    dissipation_shockCapturingFactor = 0.9
+    dissipation_lag_shockCapturing = True  #False
+    dissipation_sc_uref = 1.0
+    dissipation_sc_beta = 1.0
+
+ns_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+ns_sed_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+vof_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+vos_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+ls_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+rd_nl_atol_res =  max(opts.res, 0.005 * he)
+mcorr_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+kappa_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+dissipation_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+phi_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+pressure_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Turbulence
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+ns_closure = 0  #1-classic smagorinsky, 2-dynamic smagorinsky, 3 -- k-epsilon, 4 -- k-omega
+ns_sed_closure = 0  #1-classic smagorinsky, 2-dynamic smagorinsky, 3 -- k-epsilon, 4 -- k-omega
+if useRANS == 1:
+    ns_closure = 3
+elif useRANS == 2:
+    ns_closure == 4
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Functions for model variables - Initial conditions
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+def signedDistance(x):
+    phi_z = x[1] - waterLine_z
+    return phi_z
+
+def vos_signedDistance(x):
+    phi_z1 = x[1] - sediment_level
+    phi_z2 = sediment_bottom - x[1]
+    if abs(phi_z1) < abs(phi_z2):
+        phi_z = phi_z1
+    else:
+        phi_z = phi_z2
+    return phi_z
+
+class Suspension_class:
+    def __init__(self):
+        pass
+    def uOfXT(self, x, t=0):
+        phi = vos_signedDistance(x)
+        smoothing = (epsFact_consrv_heaviside)*he/2.
+        Heav = smoothedHeaviside(smoothing, phi)      
+        if phi <= -smoothing:
+            return opts.cSed
+        elif -smoothing < phi < smoothing:
+            return opts.cSed * (1.-Heav)            
+        else:
+            return 1e-10    
+
+Suspension = Suspension_class()
+
+vos_function = Suspension.uOfXT

--- a/2d/sediment/bed_sediment/tank_so.py
+++ b/2d/sediment/bed_sediment/tank_so.py
@@ -1,0 +1,86 @@
+from proteus import StepControl
+"""
+Split operator module for two-phase flow
+"""
+
+from proteus.default_so import *
+import os
+from proteus import Context
+
+# Create context from main module
+name_so = os.path.basename(__file__)
+if '_so.py' in name_so[-6:]:
+    name = name_so[:-6]
+elif '_so.pyc' in name_so[-7:]:
+    name = name_so[:-7]
+else:
+    raise NameError, 'Split operator module must end with "_so.py"'
+
+try:
+    case = __import__(name)
+    Context.setFromModule(case)
+    ct = Context.get()
+except ImportError:
+    raise ImportError, str(name) + '.py not found'
+
+from proteus import BoundaryConditions
+for BC in ct.domain.bc:
+    BC.getContext()
+
+from proteus.SplitOperator import Sequential_FixedStep_Simple, defaultSystem
+if ct.sedimentDynamics:
+    pnList = [("vos_p",               "vos_n"),#0
+              ("vof_p",               "vof_n"),#1
+              ("ls_p",                "ls_n"),#2
+              ("redist_p",            "redist_n"),#3
+              ("ls_consrv_p",         "ls_consrv_n"),#4
+              ("threep_navier_stokes_sed_p", "threep_navier_stokes_sed_n"),#5
+              ("twp_navier_stokes_p", "twp_navier_stokes_n"),#6
+              ("pressureincrement_p", "pressureincrement_n"),#7
+              ("pressure_p", "pressure_n")]#8
+    
+else:
+    pnList = [("vof_p",               "vof_n"),#0
+              ("ls_p",                "ls_n"),#1
+              ("redist_p",            "redist_n"),#2
+              ("ls_consrv_p",         "ls_consrv_n"),#3
+              ("twp_navier_stokes_p", "twp_navier_stokes_n"),#4
+              ("pressureincrement_p", "pressureincrement_n"),#5
+              ("pressure_p", "pressure_n")]#6
+
+if ct.useRANS > 0:
+    pnList.append(("kappa_p",
+                   "kappa_n"))#7 or #9
+    pnList.append(("dissipation_p",
+                   "dissipation_n"))#8 or #10
+
+pnList.append(("pressureInitial_p",
+                   "pressureInitial_n"))#7 or #9
+
+        
+              
+name = "tank"
+
+#modelSpinUpList = [ct.VOF_model, ct.LS_model, ct.V_model, ct.PINIT_model]
+modelSpinUpList = [ct.PI_model]
+
+class Sequential_MinAdaptiveModelStepPS(Sequential_MinAdaptiveModelStep):
+    def __init__(self,modelList,system=defaultSystem,stepExact=True):
+        Sequential_MinAdaptiveModelStep.__init__(self,modelList,system,stepExact)
+        self.modelList = modelList[:len(pnList)-1]
+
+#class Sequential_MinAdaptiveModelStepPS(Sequential_FixedStep):
+#    def __init__(self,modelList,system=defaultSystem,stepExact=True):
+#        Sequential_FixedStep.__init__(self,modelList,system,stepExact)
+#        self.modelList = modelList[:len(pnList)-1]
+#dt_system_fixed = ct.dt_fixed
+
+systemStepControllerType = Sequential_MinAdaptiveModelStepPS
+
+needEBQ_GLOBAL = False
+needEBQ = False
+
+tnList = [0.0,ct.dt_init]+[ct.dt_init+i*ct.dt_fixed for i in range(1,ct.nDTout+1)]
+
+info = open("TimeList.txt","w")
+#archiveFlag = ArchiveFlags.EVERY_SEQUENCE_STEP

--- a/2d/sediment/bed_sediment/testSeries_double
+++ b/2d/sediment/bed_sediment/testSeries_double
@@ -1,0 +1,4 @@
+# Two phase
+parun tank_so.py -l 12 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -D ref_double -C "duration=5. refinement=12.5 sediment_level=2 sediment_bottom=1 waterLine_z=0.5 cSed=0.1"
+
+

--- a/2d/sediment/bed_sediment/testSeries_single
+++ b/2d/sediment/bed_sediment/testSeries_single
@@ -1,0 +1,7 @@
+# Single phase
+parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -D ref12.5_single -C "duration=5. refinement=12.5 rho_1=998.2 nu_1=1e-6"
+parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -D ref25_single -C "duration=5. refinement=25 rho_1=998.2 nu_1=1e-6"
+parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -D ref50_single -C "duration=5. refinement=50 rho_1=998.2 nu_1=1e-6"
+parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -D ref50_single -C "duration=5. refinement=50 rho_1=998.2 nu_1=1e-6"
+
+

--- a/2d/sediment/bed_sediment/threep_navier_stokes_sed_n.py
+++ b/2d/sediment/bed_sediment/threep_navier_stokes_sed_n.py
@@ -1,0 +1,72 @@
+from proteus import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+from threep_navier_stokes_sed_p import *
+from tank import *
+
+if timeDiscretization=='vbdf':
+    timeIntegration = VBDF
+    timeOrder=2
+    stepController  = Min_dt_cfl_controller
+elif timeDiscretization=='flcbdf':
+    timeIntegration = FLCBDF
+    #stepController = FLCBDF_controller_sys
+    stepController  = Min_dt_cfl_controller
+    time_tol = 10.0*ns_sed_nl_atol_res
+    atol_u = {0:time_tol,1:time_tol}
+    rtol_u = {0:time_tol,1:time_tol}
+else:
+    timeIntegration = BackwardEuler_cfl
+    stepController  = Min_dt_cfl_controller
+
+femSpaces = {0:basis,
+	     1:basis}
+
+massLumping       = False
+numericalFluxType = None
+conservativeFlux  = None
+
+numericalFluxType = RANS3PSed.NumericalFlux
+subgridError = RANS3PSed.SubgridError(coefficients,nd,lag=ns_sed_lag_subgridError,hFactor=hFactor)
+shockCapturing = RANS3PSed.ShockCapturing(coefficients,nd,ns_sed_shockCapturingFactor,lag=ns_sed_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+
+linearSmoother    = None
+
+matrix = SparseMatrix
+
+if useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'rans3p_sed_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest             = 'r-true'
+
+tolFac = 0.0
+linTolFac = 0.01
+l_atol_res = 0.01*ns_sed_nl_atol_res
+nl_atol_res = ns_sed_nl_atol_res
+useEisenstatWalker = False
+maxNonlinearIts = 50
+maxLineSearches = 0
+conservativeFlux = {0:'point-eval'}
+#conservativeFlux = {0:'pwl-bdm-opt'}
+#auxiliaryVariables=[pointGauges,lineGauges]
+auxiliaryVariables = ct.domain.auxiliaryVariables['thp']+[ct.vs_output]

--- a/2d/sediment/bed_sediment/threep_navier_stokes_sed_p.py
+++ b/2d/sediment/bed_sediment/threep_navier_stokes_sed_p.py
@@ -1,0 +1,81 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import RANS3PSed
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = RANS3PSed.LevelModel
+
+
+coefficients = RANS3PSed.Coefficients(epsFact=epsFact_viscosity,
+                                      sigma=0.0,
+                                      rho_0 = rho_0,
+                                      nu_0 = nu_0, 
+                                      rho_1 = rho_1,
+                                      nu_1 = nu_1,
+                                      rho_s = rho_s,
+                                      g=g,
+                                      nd=nd,
+                                      ME_model=ct.SED_model,
+                                      PRESSURE_model=ct.P_model,
+                                      FLUID_model=ct.V_model,
+                                      VOS_model=ct.VOS_model,
+                                      VOF_model=ct.VOF_model,
+                                      LS_model=ct.LS_model,
+                                      Closure_0_model=ct.K_model,
+                                      Closure_1_model=ct.EPS_model,
+                                      epsFact_density=epsFact_density,
+                                      stokes=False,
+                                      useVF=True,
+                                      useRBLES=useRBLES,
+                                      useMetrics=useMetrics,
+                                      eb_adjoint_sigma=1.0,
+                                      eb_penalty_constant=weak_bc_penalty_constant,
+                                      forceStrongDirichlet=ns_forceStrongDirichlet,
+                                      turbulenceClosureModel=ns_closure,
+                                      movingDomain=movingDomain,
+                                      dragAlpha=dragAlpha,
+                                      PSTAB=ct.opts.PSTAB,
+                                    aDarcy = sedClosure.aDarcy,
+                                    betaForch = sedClosure.betaForch,
+                                    grain = sedClosure.grain,
+                                    packFraction = sedClosure.packFraction,
+                                    maxFraction = sedClosure.maxFraction,
+                                    frFraction = sedClosure.frFraction,
+                                    sigmaC = sedClosure.sigmaC,
+                                    C3e = sedClosure.C3e,
+                                    C4e = sedClosure.C4e,
+                                    eR = sedClosure.eR,
+                                    fContact = sedClosure.fContact,
+                                    mContact = sedClosure.mContact,
+                                    nContact = sedClosure.nContact,
+                                    angFriction = sedClosure.angFriction,
+                                    vos_function = ct.vos_function,
+                                    staticSediment = False,
+                                    vos_limiter = ct.sedClosure.vos_limiter,
+                                    mu_fr_limiter = ct.sedClosure.mu_fr_limiter)
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].us_dirichlet.init_cython(),
+                       1: lambda x, flag: domain.bc[flag].vs_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].us_advective.init_cython(),
+                                   1: lambda x, flag: domain.bc[flag].vs_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {0: lambda x, flag: domain.bc[flag].us_diffusive.init_cython()},
+                                   1: {1: lambda x, flag: domain.bc[flag].vs_diffusive.init_cython()}}
+
+if nd == 3:
+    dirichletConditions[2] = lambda x, flag: domain.bc[flag].ws_dirichlet.init_cython()
+    advectiveFluxBoundaryConditions[2] = lambda x, flag: domain.bc[flag].ws_advective.init_cython()
+    diffusiveFluxBoundaryConditions[2] = {2: lambda x, flag: domain.bc[flag].ws_diffusive.init_cython()}
+
+class AtRest:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+initialConditions = {0:AtRest(),
+                     1:AtRest()}

--- a/2d/sediment/bed_sediment/twp_navier_stokes_n.py
+++ b/2d/sediment/bed_sediment/twp_navier_stokes_n.py
@@ -1,0 +1,74 @@
+from proteus import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+from twp_navier_stokes_p import *
+from tank import *
+
+if timeDiscretization=='vbdf':
+    timeIntegration = VBDF
+    timeOrder=2
+    stepController  = Min_dt_cfl_controller
+elif timeDiscretization=='flcbdf':
+    timeIntegration = FLCBDF
+    #stepController = FLCBDF_controller_sys
+    stepController  = Min_dt_cfl_controller
+    time_tol = 10.0*ns_nl_atol_res
+    atol_u = {0:time_tol,1:time_tol}
+    rtol_u = {0:time_tol,1:time_tol}
+else:
+    timeIntegration = BackwardEuler_cfl
+    stepController  = Min_dt_cfl_controller
+
+femSpaces = {0:basis,
+	     1:basis}
+#femSpaces = {0:C0_AffineQuadraticOnSimplexWithNodalBasis,
+#             1:C0_AffineQuadraticOnSimplexWithNodalBasis}
+
+massLumping       = False
+numericalFluxType = None
+conservativeFlux  = None
+
+numericalFluxType = RANS3PF.NumericalFlux
+subgridError = RANS3PF.SubgridError(coefficients,nd,lag=ns_lag_subgridError,hFactor=hFactor)
+shockCapturing = RANS3PF.ShockCapturing(coefficients,nd,ns_shockCapturingFactor,lag=ns_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+
+linearSmoother    = None #SimpleNavierStokes2D
+
+matrix = SparseMatrix
+
+if useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'rans2p_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest             = 'r-true'
+
+tolFac = 0.0
+linTolFac = 0.01
+l_atol_res = 0.01*ns_nl_atol_res
+nl_atol_res = ns_nl_atol_res
+useEisenstatWalker = False
+maxNonlinearIts = 50
+maxLineSearches = 0
+conservativeFlux = {0:'point-eval'}
+#conservativeFlux = {0:'pwl-bdm-opt'}
+#auxiliaryVariables=[pointGauges,lineGauges]
+auxiliaryVariables = ct.domain.auxiliaryVariables['twp']+[ct.v_output]

--- a/2d/sediment/bed_sediment/twp_navier_stokes_p.py
+++ b/2d/sediment/bed_sediment/twp_navier_stokes_p.py
@@ -1,0 +1,129 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import RANS3PF
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = RANS3PF.LevelModel
+
+coefficients = RANS3PF.Coefficients(epsFact=epsFact_viscosity,
+                                    sigma=0.0,
+                                    rho_0 = rho_0,
+                                    nu_0 = nu_0,
+                                    rho_1 = rho_1,
+                                    nu_1 = nu_1,
+                                    g=g,
+                                    nd=nd,
+                                    ME_model=ct.V_model,
+                                    PRESSURE_model=ct.P_model,
+                                    SED_model=ct.SED_model,
+                                    VOF_model=ct.VOF_model,
+                                    VOS_model=ct.VOS_model,
+                                    LS_model=ct.LS_model,
+                                    Closure_0_model=ct.K_model,
+                                    Closure_1_model=ct.EPS_model,
+                                    epsFact_density=epsFact_density,
+                                    stokes=False,
+                                    useVF=useVF,
+                                    useRBLES=useRBLES,
+                                    useMetrics=useMetrics,
+                                    eb_adjoint_sigma=1.0,
+                                    eb_penalty_constant=weak_bc_penalty_constant,
+                                    forceStrongDirichlet=ns_forceStrongDirichlet,
+                                    turbulenceClosureModel=ns_closure,
+                                    movingDomain=movingDomain,
+                                    dragAlpha=dragAlpha,
+                                    PSTAB=ct.opts.PSTAB,
+                                    aDarcy = sedClosure.aDarcy,
+                                    betaForch = sedClosure.betaForch,
+                                    grain = sedClosure.grain,
+                                    packFraction = sedClosure.packFraction,
+                                    maxFraction = sedClosure.maxFraction,
+                                    frFraction = sedClosure.frFraction,
+                                    sigmaC = sedClosure.sigmaC,
+                                    C3e = sedClosure.C3e,
+                                    C4e = sedClosure.C4e,
+                                    eR = sedClosure.eR,
+                                    fContact = sedClosure.fContact,
+                                    mContact = sedClosure.mContact,
+                                    nContact = sedClosure.nContact,
+                                    angFriction = sedClosure.angFriction,
+                                    vos_function = ct.vos_function,
+                                    vos_limiter = ct.sedClosure.vos_limiter,
+                                    mu_fr_limiter = ct.sedClosure.mu_fr_limiter,
+                                    )
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].u_dirichlet.init_cython(),
+                       1: lambda x, flag: domain.bc[flag].v_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].u_advective.init_cython(),
+                                   1: lambda x, flag: domain.bc[flag].v_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {0: lambda x, flag: domain.bc[flag].u_diffusive.init_cython()},
+                                   1: {1: lambda x, flag: domain.bc[flag].v_diffusive.init_cython()}}
+
+if nd == 3:
+    dirichletConditions[2] = lambda x, flag: domain.bc[flag].w_dirichlet.init_cython()
+    advectiveFluxBoundaryConditions[2] = lambda x, flag: domain.bc[flag].w_advective.init_cython()
+    diffusiveFluxBoundaryConditions[2] = {2: lambda x, flag: domain.bc[flag].w_diffusive.init_cython()}
+
+class AtRest:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+
+smoothing = 3*he
+
+
+class U_IC:
+
+
+    def uOfXT(self,x,t):
+        if ct.signedDistance(x) <= -0.28:
+            H = 1
+            speed = 0
+        elif -0.278 < ct.signedDistance(x) < -0.28 + smoothing:
+            H = 1-(smoothedHeaviside(smoothing/2. , ct.signedDistance(x)+0.28 - smoothing/2.))
+            speed = ct.opts.inflow_vel
+
+        elif  (ct.signedDistance(x) <= 0): 
+        #and ct.signedDistance(x)>= -0.27+smoothing):
+            H = 0
+            speed = ct.opts.inflow_vel
+        
+        elif 0 < ct.signedDistance(x) <= smoothing:
+            H = smoothedHeaviside(smoothing/2. , ct.signedDistance(x) - smoothing/2.)
+            speed = ct.opts.inflow_vel
+        else:
+            H = 1
+            speed = 0
+        
+        u = H * 0.0 + (1-H)*speed
+
+        return u
+
+
+class V_IC:
+    def uOfXT(self,x,t):
+                
+        v = 0.0
+
+        return v
+
+
+
+
+#if ct.opts.current:
+#    initialConditions = {0: U_IC(),
+#                         1: V_IC()}
+#
+#else:    
+#    initialConditions = {0:AtRest(),
+#                         1:AtRest()}
+
+initialConditions = {0:AtRest(),
+                     1:AtRest()}

--- a/2d/sediment/bed_sediment/vof_n.py
+++ b/2d/sediment/bed_sediment/vof_n.py
@@ -1,0 +1,77 @@
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import vof_p as physics
+from proteus.mprans import VOF3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+# time stepping
+runCFL = ct.runCFL
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_controller
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = VOF3P.NumericalFlux
+conservativeFlux  = None
+subgridError      = VOF3P.SubgridError(coefficients=physics.coefficients,nd=nd)
+shockCapturing    = VOF3P.ShockCapturing(physics.coefficients,nd,shockCapturingFactor=ct.vof_shockCapturingFactor,lag=ct.vof_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'vof_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'r-true'
+
+tolFac      = 0.0
+nl_atol_res = ct.vof_nl_atol_res
+
+linTolFac   = 0.0
+l_atol_res = 0.1*ct.vof_nl_atol_res
+
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+
+auxiliaryVariables = ct.domain.auxiliaryVariables['vof']

--- a/2d/sediment/bed_sediment/vof_p.py
+++ b/2d/sediment/bed_sediment/vof_p.py
@@ -1,0 +1,39 @@
+from proteus.default_p import *
+from proteus.ctransportCoefficients import smoothedHeaviside
+from proteus.mprans import VOF3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+LevelModelType = VOF3P.LevelModel
+
+coefficients = VOF3P.Coefficients(LS_model=ct.LS_model,
+                                  V_model=ct.V_model,
+                                  RD_model=ct.RD_model,
+                                  ME_model=ct.VOF_model,
+                                  VOS_model=ct.VOS_model,
+                                  checkMass=True,
+                                  useMetrics=ct.useMetrics,
+                                  epsFact=ct.epsFact_vof,
+                                  sc_uref=ct.vof_sc_uref,
+                                  sc_beta=ct.vof_sc_beta,
+                                  movingDomain=ct.movingDomain)
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].vof_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].vof_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {}}
+
+class VF_IC:
+    def uOfXT(self, x, t):
+        return smoothedHeaviside(ct.epsFact_consrv_heaviside*mesh.he,x[nd-1]-ct.waterLevel)
+
+initialConditions = {0: VF_IC()}

--- a/2d/sediment/bed_sediment/vos_n.py
+++ b/2d/sediment/bed_sediment/vos_n.py
@@ -1,0 +1,81 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import vof_p as physics
+from proteus import Context
+from proteus.mprans import VOS3P
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+# time stepping
+runCFL = ct.runCFL
+timeIntegration = VOS3P.RKEV#BackwardEuler_cfl
+stepController  = StepControl.Min_dt_controller
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = VOS3P.NumericalFlux
+conservativeFlux  = None
+subgridError      = VOS3P.SubgridError(coefficients=physics.coefficients,nd=nd)
+shockCapturing    = VOS3P.ShockCapturing(physics.coefficients,nd,shockCapturingFactor=ct.vos_shockCapturingFactor,lag=ct.vos_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.ExplicitLumpedMassMatrix
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'vos_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'r-true'
+
+tolFac      = 0.0
+nl_atol_res = ct.vos_nl_atol_res
+
+linTolFac   = 0.0
+l_atol_res = 0.1*ct.vos_nl_atol_res
+
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+
+#auxiliaryVariables = ct.domain.auxiliaryVariables['vos']
+auxiliaryVariables = ct.domain.auxiliaryVariables['vos']+[ct.vos_output]

--- a/2d/sediment/bed_sediment/vos_p.py
+++ b/2d/sediment/bed_sediment/vos_p.py
@@ -1,0 +1,40 @@
+from proteus import StepControl
+from proteus.default_p import *
+from proteus.ctransportCoefficients import smoothedHeaviside
+from proteus.mprans import VOS3P
+from proteus import Context
+from proteus import *
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+LevelModelType = VOS3P.LevelModel
+
+coefficients = VOS3P.Coefficients(V_model=ct.V_model,
+                                  SED_model=ct.SED_model,
+                                  ME_model=ct.VOS_model,
+                                  checkMass=False,
+                                  useMetrics=ct.useMetrics,
+                                  epsFact=ct.epsFact_vos,
+                                  sc_uref=ct.vos_sc_uref,
+                                  sc_beta=ct.vos_sc_beta,
+                                  movingDomain=ct.movingDomain,
+                                  vos_function=ct.vos_function,
+                                  global_max_u=ct.opts.vos_limiter,
+                                  STABILIZATION_TYPE=4,
+                                  LUMPED_MASS_MATRIX=True,
+                                  cE = 1.,
+                                  cK=0.
+                                  
+                                  )
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].vos_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].vos_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {}}
+
+
+initialConditions  = {0:ct.Suspension}

--- a/2d/sediment/friction_angle_dambrek_sediment/TimeSeriesPlot.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/TimeSeriesPlot.py
@@ -1,0 +1,54 @@
+from proteus import StepControl
+#from scipy import *
+from pylab import *
+from numpy import *
+import collections as cll
+
+filename='pointGauge_pressure.txt'
+headerline = 0
+
+
+# Read header info 
+
+fid = open(filename,'r')
+prdata=loadtxt(fid,skiprows=headerline)
+fid.seek(0)
+D = fid.readlines()
+header = D[:headerline]
+n=len(D)
+
+a = array(zeros((int(n),5)))
+step = zeros(int(n),float)
+for i in range (int(n)):
+ a[i,:]=D[i].split()
+ step[i]=i
+
+a = array(a,dtype=float32)
+
+y = zeros(int(n),float)
+
+y[:] = a[:,2]
+
+
+
+
+
+
+#j=str(2)
+
+fig1 = figure(1)
+fig1.add_subplot(1,1,1)
+plot(step[:],y[:],"k",lw=2)
+
+##xlim(80,90)
+##ylim(-0.05,0.05)
+
+grid()
+#title('Surface elevation at $x=$' + str(probex[int(j)])+'m')
+title('Point gauge pressure evolution')
+xlabel('Step')
+ylabel('Pressure')
+
+show()
+savefig('plottrial.pdf')
+savefig('plottrial.png',dpi=100)

--- a/2d/sediment/friction_angle_dambrek_sediment/dissipation_n.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/dissipation_n.py
@@ -1,0 +1,59 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import dissipation_p as physics
+from proteus import Context
+from proteus.mprans import Dissipation
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+triangleOptions = mesh.triangleOptions
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_cfl_controller
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = Dissipation.NumericalFlux
+conservativeFlux  = None
+subgridError      = Dissipation.SubgridError(coefficients=physics.coefficients,nd=ct.nd)
+shockCapturing    = Dissipation.ShockCapturing(physics.coefficients,ct.nd,shockCapturingFactor=ct.dissipation_shockCapturingFactor,
+                                         lag=ct.dissipation_lag_shockCapturing)
+
+fullNewtonFlag  = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+#printNonlinearSolverInfo = True
+matrix = SparseMatrix
+if not ct.useOldPETSc and not ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+else:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'dissipation_'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'rits'
+
+tolFac = 0.0
+linTolFac =0.0
+l_atol_res = 0.001*ct.dissipation_nl_atol_res
+nl_atol_res = ct.dissipation_nl_atol_res
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+

--- a/2d/sediment/friction_angle_dambrek_sediment/dissipation_p.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/dissipation_p.py
@@ -1,0 +1,58 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import Dissipation
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = Dissipation.LevelModel
+if useOnlyVF:
+    RD_model = None
+    LS_model = None
+    dissipation_model = 3
+    ME_model = 2
+else:
+    RD_model = 3
+    LS_model = 2
+    ME_model = 6
+    kappa_model = 5
+
+dissipation_model_flag = 1
+if ct.useRANS >= 2:
+    dissipation_model_flag=2
+coefficients = Dissipation.Coefficients(V_model=0+int(ct.movingDomain),
+                                        ME_model=ME_model+int(ct.movingDomain),
+                                        LS_model=LS_model+int(ct.movingDomain),
+                                        RD_model=RD_model+int(ct.movingDomain),
+                                        kappa_model=kappa_model+int(ct.movingDomain),
+                                        dissipation_model_flag=dissipation_model_flag+int(ct.movingDomain),#1 -- K-epsilon, 2 -- K-omega
+                                  useMetrics=useMetrics,
+                                  rho_0=rho_0,nu_0=nu_0,
+                                  rho_1=rho_1,nu_1=nu_1,
+                                  g=g,
+                                  c_mu=ct.opts.Cmu,sigma_e=ct.opts.sigma_e,
+                                  sc_uref=dissipation_sc_uref,
+                                  sc_beta=dissipation_sc_beta)
+
+kInflow=ct.kInflow
+
+dissipationInflow=ct.dissipationInflow
+
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].dissipation_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].dissipation_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {},
+                                   1: {1: lambda x, flag: domain.bc[flag].dissipation_diffusive.init_cython()},
+                                  }
+
+ 
+class ConstantIC:
+    def __init__(self,cval=0.0):
+        self.cval=cval
+    def uOfXT(self,x,t):
+        return self.cval
+
+initialConditions  = {0:ConstantIC(cval=dissipationInflow)}

--- a/2d/sediment/friction_angle_dambrek_sediment/eddy_viscosity_view_batch.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/eddy_viscosity_view_batch.py
@@ -1,0 +1,7 @@
+from proteus import StepControl
+#0 is Navier-Stokes flow model
+simFlagsList[0]['storeQuantities']= ['simulationData',"q:'eddy_viscosity'"]
+simFlagsList[0]['storeTimes']     = ['All']
+#
+start
+quit

--- a/2d/sediment/friction_angle_dambrek_sediment/kappa_n.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/kappa_n.py
@@ -1,0 +1,61 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import kappa_p as physics
+from proteus import Context
+from proteus.mprans import Kappa
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+triangleOptions = mesh.triangleOptions
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_cfl_controller
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = Kappa.NumericalFlux
+conservativeFlux  = None
+subgridError      = Kappa.SubgridError(coefficients=physics.coefficients,nd=ct.nd)
+shockCapturing    = Kappa.ShockCapturing(physics.coefficients,ct.nd,shockCapturingFactor=ct.kappa_shockCapturingFactor,
+                                         lag=ct.kappa_lag_shockCapturing)
+
+fullNewtonFlag  = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+#printNonlinearSolverInfo = True
+matrix = SparseMatrix
+if not ct.useOldPETSc and not ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+else:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'kappa_'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'rits'
+
+tolFac = 0.0
+linTolFac =0.0
+l_atol_res = 0.001*ct.kappa_nl_atol_res
+nl_atol_res = ct.kappa_nl_atol_res
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+
+auxiliaryVariables = ct.domain.auxiliaryVariables['kappa']
+

--- a/2d/sediment/friction_angle_dambrek_sediment/kappa_p.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/kappa_p.py
@@ -1,0 +1,57 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import Kappa
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = Kappa.LevelModel
+if useOnlyVF:
+    RD_model = None
+    LS_model = None
+    dissipation_model = 3
+    ME_model = 2
+else:
+    RD_model = 3
+    LS_model = 2
+    ME_model = 5
+    dissipation_model = 6
+
+dissipation_model_flag = 1
+if ct.useRANS >= 2:
+    dissipation_model_flag=2
+
+coefficients = Kappa.Coefficients(V_model=0+int(ct.movingDomain),
+                                  ME_model=ME_model+int(ct.movingDomain),
+                                  LS_model=LS_model+int(ct.movingDomain),
+                                  RD_model=RD_model+int(ct.movingDomain),
+                                  dissipation_model=dissipation_model+int(ct.movingDomain),
+                                  dissipation_model_flag=dissipation_model_flag+int(ct.movingDomain),#1 -- K-epsilon, 2 -- K-omega
+                                  useMetrics=useMetrics,
+                                  rho_0=rho_0,nu_0=nu_0,
+                                  rho_1=rho_1,nu_1=nu_1,
+                                  g=g,
+                                  c_mu=ct.opts.Cmu,sigma_k=ct.opts.sigma_k, 
+                                  sc_uref=kappa_sc_uref,
+                                  sc_beta=kappa_sc_beta)
+
+kInflow=ct.kInflow
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].k_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].k_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {},
+                                   1: {1: lambda x, flag: domain.bc[flag].k_diffusive.init_cython()},
+                                  }
+
+
+class ConstantIC:
+    def __init__(self,cval=0.0):
+        self.cval=cval
+    def uOfXT(self,x,t):
+        return self.cval
+
+   
+initialConditions  = {0:ConstantIC(cval=kInflow)}

--- a/2d/sediment/friction_angle_dambrek_sediment/ls_consrv_n.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/ls_consrv_n.py
@@ -1,0 +1,78 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools,
+                     NumericalFlux)
+import ls_consrv_p as physics
+from proteus import Context
+from proteus.mprans.MCorr3P import DummyNewton
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+#time stepping
+runCFL = ct.runCFL
+timeIntegrator  = TimeIntegration.ForwardIntegrator
+timeIntegration = TimeIntegration.NoIntegration
+
+#mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0:ct.basis}
+
+subgridError      = None
+massLumping       = False
+numericalFluxType = ct.DoNothing
+conservativeFlux  = None
+shockCapturing    = None
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+#multilevelNonlinearSolver = DummyNewton
+#levelNonlinearSolver      = DummyNewton
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'mcorr_'
+nonlinearSolverConvergenceTest  = 'rits'
+levelNonlinearSolverConvergenceTest  = 'rits'
+linearSolverConvergenceTest  = 'r-true'
+
+tolFac = 0.0
+linTolFac = 0.01
+l_atol_res = 0.01*ct.mcorr_nl_atol_res
+nl_atol_res = ct.mcorr_nl_atol_res
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0

--- a/2d/sediment/friction_angle_dambrek_sediment/ls_consrv_p.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/ls_consrv_p.py
@@ -1,0 +1,53 @@
+from proteus import StepControl
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import MCorr3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+
+LevelModelType = MCorr3P.LevelModel
+
+if ct.sedimentDynamics:
+    VOS_model=0
+    VOF_model=1
+    LS_model=2
+    MCORR_model=4
+    V_model=6
+else:
+    VOS_model=None
+    VOF_model=0
+    LS_model=1
+    MCORR_model=3
+    V_model=4
+
+coefficients = MCorr3P.Coefficients(LS_model=LS_model,
+                                    V_model=V_model,
+                                    ME_model=MCORR_model,
+                                    VOF_model=VOF_model,
+                                    VOS_model=VOS_model,
+                                    applyCorrection=ct.applyCorrection,
+                                    nd=nd,
+                                    checkMass=False,
+                                    useMetrics=ct.useMetrics,
+                                    epsFactHeaviside=ct.epsFact_consrv_heaviside,
+                                    epsFactDirac=ct.epsFact_consrv_dirac,
+                                    epsFactDiffusion=ct.epsFact_consrv_diffusion)
+
+class zero_phi:
+    def __init__(self):
+        pass
+    def uOfX(self,X):
+        return 0.0
+    def uOfXT(self,X,t):
+        return 0.0
+
+initialConditions  = {0:zero_phi()}

--- a/2d/sediment/friction_angle_dambrek_sediment/ls_n.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/ls_n.py
@@ -1,0 +1,78 @@
+from proteus import StepControl
+from proteus.default_n import *
+import ls_p as physics
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+from proteus.mprans import NCLS3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+coefficients = physics.coefficients
+
+# time stepping
+runCFL = ct.runCFL
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_controller
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0: ct.basis}
+
+massLumping       = False
+conservativeFlux  = None
+numericalFluxType = NCLS3P.NumericalFlux
+subgridError      = NCLS3P.SubgridError(coefficients,nd)
+shockCapturing    = NCLS3P.ShockCapturing(coefficients,nd,shockCapturingFactor=ct.ls_shockCapturingFactor,lag=ct.ls_lag_shockCapturing)
+
+fullNewtonFlag  = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'ncls_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'r-true'
+
+tolFac = 0.0
+nl_atol_res = ct.ls_nl_atol_res
+linTolFac = 0.0
+l_atol_res = 0.1*ct.ls_nl_atol_res
+
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+
+auxiliaryVariables = ct.domain.auxiliaryVariables['ls']

--- a/2d/sediment/friction_angle_dambrek_sediment/ls_p.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/ls_p.py
@@ -1,0 +1,48 @@
+from proteus import StepControl
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import NCLS3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+
+LevelModelType = NCLS3P.LevelModel
+
+if ct.sedimentDynamics:
+    LS_model=2
+    RD_model=3
+    V_model=6
+else:
+    LS_model=1
+    RD_model=2
+    V_model=4
+
+coefficients = NCLS3P.Coefficients(V_model=V_model,
+                                   RD_model=RD_model,
+                                   ME_model=LS_model,
+                                   checkMass=False,
+                                   useMetrics=ct.useMetrics,
+                                   epsFact=ct.epsFact_consrv_heaviside,
+                                   sc_uref=ct.ls_sc_uref,
+                                   sc_beta=ct.ls_sc_beta,
+                                   movingDomain=ct.movingDomain)
+
+dirichletConditions = {0: lambda x, flag: None}
+
+advectiveFluxBoundaryConditions = {}
+
+diffusiveFluxBoundaryConditions = {0: {}}
+
+class PHI_IC:
+    def uOfXT(self, x, t):
+        return x[nd-1] - ct.waterLevel
+
+initialConditions = {0: PHI_IC()}

--- a/2d/sediment/friction_angle_dambrek_sediment/pressureInitial_n.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/pressureInitial_n.py
@@ -1,0 +1,54 @@
+from proteus import *
+from proteus.default_n import *
+from pressureInitial_p import *
+
+
+mesh = domain.MeshOptions
+triangleOptions = triangleOptions
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+
+femSpaces = {0:ct.pbasis}
+
+stepController=FixedStep
+
+#numericalFluxType = NumericalFlux.ConstantAdvection_Diffusion_SIPG_exterior #weak boundary conditions (upwind ?)
+matrix = LinearAlgebraTools.SparseMatrix
+
+#linearSmoother    = LinearSolvers.NavierStokesPressureCorrection # pure neumann laplacian solver
+#multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+#levelLinearSolver = LinearSolvers.KSP_petsc4py
+#linearSmoother    = None
+#multilevelLinearSolver = LinearSolvers.LU
+#levelLinearSolver      = LinearSolvers.LU
+numericalFluxType = NumericalFlux.ConstantAdvection_exterior
+#numericalFluxType = NumericalFlux
+
+linear_solver_options_prefix = 'pinit_'
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+else:
+    multilevelLinearSolver = KSP_petsc4py
+    levelLinearSolver      = KSP_petsc4py
+    parallelPartitioningType    = parallelPartitioningType
+    nLayersOfOverlapForParallel = nLayersOfOverlapForParallel
+    nonlinearSmoother = None
+    linearSmoother    = None
+
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+#linear solve rtolerance
+
+linTolFac = 0.0
+l_atol_res = 0.01*ct.phi_nl_atol_res
+tolFac = 0.0
+nl_atol_res = ct.phi_nl_atol_res
+nonlinearSolverConvergenceTest = 'r'
+levelNonlinearSolverConvergenceTest = 'r'
+linearSolverConvergenceTest             = 'r-true'
+maxLineSearches=0
+periodicDirichletConditions=None
+
+conservativeFlux=None

--- a/2d/sediment/friction_angle_dambrek_sediment/pressureInitial_p.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/pressureInitial_p.py
@@ -1,0 +1,52 @@
+from math import *
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import PresInit
+from proteus import Context
+from tank import *
+
+ct = Context.get()
+name = "pressureInitial"
+
+if ct.sedimentDynamics:
+    V_model=6
+    PRESSURE_model=8
+    PINIT_model=9
+else:
+    V_model=4
+    PRESSURE_model=6
+    PINIT_model=7
+
+coefficients=PresInit.Coefficients(nd=nd,
+                                   modelIndex=PINIT_model,
+                                   fluidModelIndex=V_model,
+                                   pressureModelIndex=PRESSURE_model)
+
+#pressure increment should be zero on any pressure dirichlet boundaries
+
+#the advectiveFlux should be zero on any no-flow  boundaries
+
+
+class getIBC_pInit:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+class PerturbedSurface_p:
+    def __init__(self,waterLevel):
+        self.waterLevel=waterLevel
+    def uOfXT(self,x,t):
+        self.vos = ct.vos_function(x)
+        self.rho_a = rho_1#(1.-self.vos)*rho_1 + (self.vos)*ct.rho_s
+        self.rho_w = rho_0#(1.-self.vos)*rho_0 + (self.vos)*ct.rho_s
+        if signedDistance(x) < 0:
+            return -(L[1] - self.waterLevel)*self.rho_a*g[1] - (self.waterLevel - x[1])*self.rho_w*g[1]
+        else:
+            return -(L[1] - x[1])*self.rho_a*g[1]
+
+initialConditions = {0:PerturbedSurface_p(waterLine_z)} #getIBC_pInit()}
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].pInit_dirichlet.init_cython()}
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].pInit_advective.init_cython()}
+diffusiveFluxBoundaryConditions = {0:{0: lambda x, flag: domain.bc[flag].pInit_diffusive.init_cython()}}

--- a/2d/sediment/friction_angle_dambrek_sediment/pressure_n.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/pressure_n.py
@@ -1,0 +1,53 @@
+from proteus import *
+from proteus.default_n import *
+from pressure_p import *
+
+
+mesh = domain.MeshOptions
+triangleOptions = triangleOptions
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+
+femSpaces = {0:ct.pbasis}
+
+
+# stepController  = StepControl.Min_dt_cfl_controller
+# runCFL= 0.99
+# runCFL= 0.5
+
+stepController=FixedStep
+
+#matrix type
+numericalFluxType = NumericalFlux.ConstantAdvection_exterior
+#numericalFluxType = NumericalFlux
+matrix = LinearAlgebraTools.SparseMatrix
+
+linear_solver_options_prefix = 'pressure_'
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+else:
+    multilevelLinearSolver = KSP_petsc4py
+    levelLinearSolver      = KSP_petsc4py
+    parallelPartitioningType    = parallelPartitioningType
+    nLayersOfOverlapForParallel = nLayersOfOverlapForParallel
+    nonlinearSmoother = None
+    linearSmoother    = None
+
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+#linear solve rtolerance
+
+linTolFac = 0.0
+l_atol_res = 0.1*ct.pressure_nl_atol_res
+tolFac = 0.0
+nl_atol_res = ct.pressure_nl_atol_res
+maxLineSearches = 0
+nonlinearSolverConvergenceTest      = 'r'
+levelNonlinearSolverConvergenceTest = 'r'
+linearSolverConvergenceTest         = 'r-true'
+
+periodicDirichletConditions=None
+
+conservativeFlux=None

--- a/2d/sediment/friction_angle_dambrek_sediment/pressure_p.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/pressure_p.py
@@ -1,0 +1,44 @@
+from math import *
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import Pres
+from proteus import Context
+from tank import *
+
+ct = Context.get()
+name = "pressure"
+
+LevelModelType = Pres.LevelModel
+
+if ct.sedimentDynamics:
+    V_model=6
+    PINC_model=7
+    PRESSURE_model=8
+
+else:
+    V_model=4
+    PINC_model=5
+    PRESSURE_model=6
+
+coefficients=Pres.Coefficients(modelIndex=PRESSURE_model,
+                               fluidModelIndex=V_model,
+                               pressureIncrementModelIndex=PINC_model,
+                               useRotationalForm=True)
+
+
+class getIBC_p:
+    def __init__(self,waterLevel):
+        self.waterLevel=waterLevel
+    def uOfXT(self,x,t):
+        self.vos = ct.vos_function(x)
+        self.rho_a = rho_1#(1.-self.vos)*rho_1 + (self.vos)*ct.rho_s
+        self.rho_w = rho_0#(1.-self.vos)*rho_0 + (self.vos)*ct.rho_s
+        if signedDistance(x) < 0:
+            return -(L[1] - self.waterLevel)*self.rho_a*g[1] - (self.waterLevel - x[1])*self.rho_w*g[1]
+        else:
+            return -(L[1] - x[1])*self.rho_a*g[1]
+
+initialConditions = {0:getIBC_p(waterLine_z)}
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].p_dirichlet.init_cython() } # pressure bc are explicitly set
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].p_advective.init_cython()}

--- a/2d/sediment/friction_angle_dambrek_sediment/pressureincrement_n.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/pressureincrement_n.py
@@ -1,0 +1,56 @@
+from proteus import *
+from proteus.default_n import *
+from pressureincrement_p import *
+
+mesh = domain.MeshOptions
+triangleOptions = triangleOptions
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+
+femSpaces = {0:pbasis}
+
+stepController=FixedStep
+
+#numericalFluxType = PresInc.NumericalFlux
+numericalFluxType = NumericalFlux.ConstantAdvection_exterior
+matrix = LinearAlgebraTools.SparseMatrix
+
+#if openTop:
+#    linearSmoother    = None
+#    multilevelLinearSolver = LinearSolvers.LU
+#    levelLinearSolver      = LinearSolvers.LU
+#else:
+#    linearSmoother         = LinearSolvers.NavierStokesPressureCorrection # pure neumann laplacian solver
+#    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+#    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+linear_solver_options_prefix = 'phi_'
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+else:
+    multilevelLinearSolver = KSP_petsc4py
+    levelLinearSolver      = KSP_petsc4py
+    parallelPartitioningType    = parallelPartitioningType
+    nLayersOfOverlapForParallel = nLayersOfOverlapForParallel
+    nonlinearSmoother = None
+    linearSmoother    = None
+
+
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+#linear solve rtolerance
+
+linTolFac = 0.0
+l_atol_res = 0.01*phi_nl_atol_res
+tolFac = 0.0
+nl_atol_res = phi_nl_atol_res
+nonlinearSolverConvergenceTest = 'r'
+levelNonlinearSolverConvergenceTest = 'r'
+linearSolverConvergenceTest             = 'r-true'
+maxLineSearches=0
+periodicDirichletConditions=None
+
+conservativeFlux = {0:'point-eval'} #'point-eval','pwl-bdm-opt'
+#conservativeFlux=None

--- a/2d/sediment/friction_angle_dambrek_sediment/pressureincrement_p.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/pressureincrement_p.py
@@ -1,0 +1,63 @@
+from math import *
+from proteus import *
+from proteus.default_p import *
+from tank import *
+import tank_so
+from proteus.mprans import PresInc
+from proteus import Context
+
+ct = Context.get()
+
+if ct.sedimentDynamics:
+    VOS_model=0
+    VOF_model=1
+    V_model=6
+    SED_model=5
+    PINC_model=7
+else:
+    VOS_model=None
+    VOF_model=0
+    V_model=4
+    PINC_model=5
+    SED_model=None
+
+
+#domain = ctx.domain
+#nd = ctx.nd
+name = "pressureincrement"
+
+LevelModelType = PresInc.LevelModel
+#from ProjectionScheme import PressureIncrement
+#coefficients=PressureIncrement(rho_f_min = rho_1,
+#                               rho_s_min = rho_s,
+#                               nd = nd,
+#                               modelIndex=PINC_model,
+#                               fluidModelIndex=V_model)
+from proteus.mprans import PresInc
+coefficients=PresInc.Coefficients(rho_f_min = (1.0-1.0e-8)*rho_1,
+                                  rho_s_min = (1.0-1.0e-8)*rho_s,
+                                  nd = nd,
+                                  modelIndex= PINC_model,
+                                  fluidModelIndex= V_model,
+                                  sedModelIndex= SED_model,
+                                  VOF_model= VOF_model,
+                                  VOS_model= VOS_model,
+                                  fixNullSpace=fixNullSpace_PresInc, 
+                                  INTEGRATE_BY_PARTS_DIV_U=ct.INTEGRATE_BY_PARTS_DIV_U_PresInc)
+
+
+#pressure increment should be zero on any pressure dirichlet boundaries
+
+#the advectiveFlux should be zero on any no-flow  boundaries
+
+class getIBC_phi:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+initialConditions = {0:getIBC_phi()}
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].pInc_dirichlet.init_cython()}
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].pInc_advective.init_cython()}
+diffusiveFluxBoundaryConditions = {0:{0: lambda x, flag: domain.bc[flag].pInc_diffusive.init_cython()}}

--- a/2d/sediment/friction_angle_dambrek_sediment/redist_n.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/redist_n.py
@@ -1,0 +1,95 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools,
+                     NumericalFlux)
+from proteus.mprans import RDLS3P
+import redist_p as physics
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+# time stepping
+runCFL = ct.runCFL
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0: ct.basis}
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+massLumping       = False
+numericalFluxType = NumericalFlux.DoNothing
+conservativeFlux  = None
+subgridError      = RDLS3P.SubgridError(physics.coefficients,nd)
+shockCapturing    = RDLS3P.ShockCapturing(physics.coefficients,nd,shockCapturingFactor=ct.rd_shockCapturingFactor,lag=ct.rd_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver  = NonlinearSolvers.Newton
+levelNonlinearSolver       = NonlinearSolvers.Newton
+
+nonlinearSmoother = NonlinearSolvers.NLGaussSeidel
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+if ct.redist_Newton:
+    timeIntegration = NoIntegration
+    stepController = ct.Newton_controller
+    maxNonlinearIts = 50
+    maxLineSearches = 0
+    nonlinearSolverConvergenceTest = 'rits'
+    levelNonlinearSolverConvergenceTest = 'rits'
+    linearSolverConvergenceTest = 'r-true'
+    useEisenstatWalker = False
+else:
+    timeIntegration = BackwardEuler_cfl
+    stepController = RDLS3P.PsiTC
+    runCFL=2.0
+    psitc['nStepsForce']=3
+    psitc['nStepsMax']=50
+    psitc['reduceRatio']=10.0
+    psitc['startRatio']=1.0
+    rtol_res[0] = 0.0
+    atol_res[0] = rd_nl_atol_res
+    useEisenstatWalker = False#True
+    maxNonlinearIts = 1
+    maxLineSearches = 0
+    nonlinearSolverConvergenceTest = 'rits'
+    levelNonlinearSolverConvergenceTest = 'rits'
+    linearSolverConvergenceTest = 'r-true'
+
+linear_solver_options_prefix = 'rdls_'
+
+tolFac = 0.0
+nl_atol_res = ct.rd_nl_atol_res
+linTolFac = 0.01
+l_atol_res = 0.01*ct.rd_nl_atol_res
+useEisenstatWalker = False#True

--- a/2d/sediment/friction_angle_dambrek_sediment/redist_p.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/redist_p.py
@@ -1,0 +1,52 @@
+from proteus import StepControl
+from proteus import *
+from proteus.default_p import *
+from math import *
+from proteus.mprans import RDLS3P
+from proteus import Context
+
+"""
+The redistancing equation in the sloshbox test problem.
+"""
+
+ct = Context.get()
+domain = ct.domain
+nd = domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+
+LevelModelType = RDLS3P.LevelModel
+
+if ct.sedimentDynamics:
+    LS_model=2
+    RD_model=3
+else:
+    LS_model=1
+    RD_model=2
+
+
+coefficients = RDLS3P.Coefficients(applyRedistancing=ct.applyRedistancing,
+                                   epsFact=ct.epsFact_redistance,
+                                   nModelId=LS_model,
+                                   rdModelId=RD_model,
+                                   useMetrics=ct.useMetrics,
+                                   backgroundDiffusionFactor=ct.backgroundDiffusionFactor)
+
+def getDBC_rd(x,flag):
+    pass
+
+dirichletConditions     = {0:getDBC_rd}
+weakDirichletConditions = {0:RDLS3P.setZeroLSweakDirichletBCsSimple}
+
+advectiveFluxBoundaryConditions =  {}
+diffusiveFluxBoundaryConditions = {0:{}}
+
+class PHI_IC:
+    def uOfXT(self, x, t):
+        return x[nd-1] - ct.waterLevel
+
+initialConditions  = {0: PHI_IC()}

--- a/2d/sediment/friction_angle_dambrek_sediment/run.sh
+++ b/2d/sediment/friction_angle_dambrek_sediment/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir $1
+cp tank.py $1/tank.py
+mpirun -np 4 parun -l 5 -v tank_so.py -O ../../../inputTemplates/petsc.options.asm -D $1

--- a/2d/sediment/friction_angle_dambrek_sediment/tank.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/tank.py
@@ -1,0 +1,449 @@
+from proteus import StepControl
+from math import *
+import proteus.MeshTools
+from proteus import Domain, Context
+from proteus.default_n import *
+from proteus.Profiling import logEvent
+from proteus.mprans import SpatialTools as st
+from proteus import Gauges as ga
+from proteus import WaveTools as wt
+from proteus.mprans.SedClosure import  HsuSedStress
+
+
+opts=Context.Options([
+    # predefined test cases
+    ("waterLine_vos_x", 1.0, "Width of free surface from left to right"),
+    ("waterLine_vos_z", 0.7, "Column height"),
+    ("waterLine_z", 1.2, "Heigth of free surface above bottom"),
+    ("Lx", 1.50, "Length of the numerical domain"),
+    ("Ly", 1.5, "Heigth of the numerical domain"),
+    ("dtout", 0.05, "Time interval for output"),
+    # sediment parameters
+    ('cSed', 0.55,'Sediment concentration'),
+	('rho_s',2600 ,'sediment material density'),
+    ('alphaSed', 150.,'laminar drag coefficient'),
+    ('betaSed', 0.0,'turbulent drag coefficient'),
+    ('grain',0.0025, 'Grain size'),
+    ('packFraction',0.2,'threshold for loose / packed sediment'),
+    ('packMargin',0.01,'transition margin for loose / packed sediment'),
+    ('maxFraction',0.635,'fraction at max  sediment packing'),
+    ('frFraction',0.57,'fraction where contact stresses kick in'),
+    ('sigmaC',1.1,'Schmidt coefficient for turbulent diffusion'),
+    ('C3e',1.2,'Dissipation coefficient '),
+    ('C4e',1.0,'Dissipation coefficient'),
+    ('eR', 0.8, 'Collision stress coefficient (module not functional)'),
+    ('fContact', 0.05,'Contact stress coefficient'),
+    ('mContact', 3.0,'Contact stress coefficient'),
+    ('nContact', 5.0,'Contact stress coefficient'),
+    ('angFriction', pi/6., 'Angle of friction'),
+    ("vos_limiter", 0.633,"Limit for VOS through contact pressure"),
+    ('mu_fr_limiter', 1.,'Hard limiter for contact stress friction coeff'),
+	# numerical options
+    ("refinement", 50.,"L[0]/refinement"),
+    ("sedimentDynamics", True, "Enable sediment dynamics module"),
+    ("cfl", 0.25 ,"Target cfl"),
+    ("duration", 1.0 ,"Duration of the simulation"),
+    ("PSTAB", 1.0, "Affects subgrid error"),
+    ("res", 1.0e-10, "Residual tolerance"),
+    ("epsFact_density", 3.0, "Control width of water/air transition zone"),
+    ("epsFact_consrv_diffusion", 1.0, "Affects smoothing diffusion in mass conservation"),
+    ("useRANS", 0, "Switch ON turbulence models: 0-None, 1-K-Epsilon, 2-K-Omega1998, 3-K-Omega1988"), # ns_closure: 1-classic smagorinsky, 2-dynamic smagorinsky, 3-k-epsilon, 4-k-omega
+    ("sigma_k", 1.0, "sigma_k coefficient for the turbulence model"),
+    ("sigma_e", 1.0, "sigma_e coefficient for the turbulence model"),
+    ("Cmu", 0.09, "Cmu coefficient for the turbulence model"),
+    ])
+
+
+# ----- Sediment stress ----- #
+
+sedClosure = HsuSedStress(aDarcy =  opts.alphaSed,
+                          betaForch =  opts.betaSed,
+                          grain =  opts.grain,
+                          packFraction =  opts.packFraction,
+                          packMargin =  opts.packMargin,
+                          maxFraction =  opts.maxFraction,
+                          frFraction =  opts.frFraction,
+                          sigmaC =  opts.sigmaC,
+                          C3e =  opts.C3e,
+                          C4e =  opts.C4e,
+                          eR =  opts.eR,
+                          fContact =  opts.fContact,
+                          mContact =  opts.mContact,
+                          nContact =  opts.nContact,
+                          angFriction =  opts.angFriction,
+                          vos_limiter = opts.vos_limiter,
+                          mu_fr_limiter = opts.mu_fr_limiter,
+						 )
+
+
+# ----- DOMAIN ----- #
+
+domain = Domain.PlanarStraightLineGraphDomain()
+
+
+# ----- Phisical constants ----- #
+  
+# Water
+rho_0 = 998.2
+nu_0 = 1.004e-6
+
+# Air
+rho_1 =  1.205 
+nu_1 =  1.500e-5  
+
+# Sediment
+
+rho_s = 2600.0 # rho_0
+nu_s = 1000000.0 # 0.0 # nu_0 # 
+dragAlpha = 0.0
+
+# Surface tension
+sigma_01 = 0.0
+
+# Gravity
+g = np.array([0.0, -9.8, 0.0])
+gamma_0 = abs(g[1])*rho_0
+
+# Initial condition
+waterLine_z = opts.waterLine_z
+waterLevel = waterLine_z
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Domain and mesh
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+L = (opts.Lx, opts.Ly)
+he = L[0]/opts.refinement
+dim = dimx, dimy = L
+coords = [ dimx/2., dimy/2. ]
+
+boundaryOrientations = {'y-': np.array([0., -1.,0.]),
+                        'x+': np.array([+1, 0.,0.]),
+                        'y+': np.array([0., +1.,0.]),
+                        'x-': np.array([-1., 0.,0.]),
+                        'sponge': None,
+                           }
+boundaryTags = {'y-': 1,
+                    'x+': 2,
+                    'y+': 3,
+                    'x-': 4,
+                    'sponge': 5,
+                       }
+
+tank = st.Rectangle(domain, dim=dim, coords=coords)
+
+
+#############################################################################################################################################################################################################################################################################################################################################################################################
+# ----- BOUNDARY CONDITIONS ----- #
+#############################################################################################################################################################################################################################################################################################################################################################################################
+
+tank.BC['y-'].setFreeSlip()
+tank.BC['y+'].setFreeSlip()
+tank.BC['x-'].setFreeSlip()
+tank.BC['x+'].setFreeSlip()
+tank.BC['y-'].vos_dirichlet.setConstantBC(0.635)
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Turbulence
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+
+if opts.useRANS:
+    kInflow = 1e-6
+    dissipationInflow = 1e-6
+    tank.BC['x-'].setTurbulentZeroGradient()
+    tank.BC['x+'].setTurbulentZeroGradient()
+    tank.BC['y-'].setTurbulentZeroGradient()
+    tank.BC['y+'].setTurbulentZeroGradient()
+
+
+######################################################################################################################################################################################################################
+# Gauges and probes #
+######################################################################################################################################################################################################################
+
+T=opts.duration
+PG = []
+gauge_dy=0.01
+tank_dim_y=dimy
+nprobes=int(tank_dim_y/gauge_dy)+1
+probes=np.linspace(0., tank_dim_y, nprobes)
+for i in probes:
+    PG.append((dimx/2., i, 0.),)
+v_output = ga.PointGauges(gauges=((('u',), PG),
+                                  (('v',), PG),),
+                          activeTime = (0., T),
+                          sampleRate=0.,
+                          fileName='fluidVelocityGauges.csv')
+vs_output = ga.PointGauges(gauges=((('us',),PG), 
+                                   (('vs',),PG),),
+                          activeTime = (0., T),
+                          sampleRate=0.,
+                          fileName='solidVelocityGauges.csv')
+vos_output = ga.PointGauges(gauges=((('vos',),PG),),
+                          activeTime = (0., T),
+                          sampleRate=0.,
+                          fileName='solidFractionGauges.csv')
+
+
+######################################################################################################################################################################################################################
+# Numerical Options and other parameters #
+######################################################################################################################################################################################################################
+ 
+domain.MeshOptions.he = he
+
+from math import *
+from proteus import MeshTools, AuxiliaryVariables
+import numpy
+import proteus.MeshTools
+from proteus import Domain
+from proteus.Profiling import logEvent
+from proteus.default_n import *
+from proteus.ctransportCoefficients import smoothedHeaviside
+from proteus.ctransportCoefficients import smoothedHeaviside_integral
+
+st.assembleDomain(domain)
+
+
+#----------------------------------------------------
+# Time stepping and velocity
+#----------------------------------------------------
+
+T=opts.duration
+weak_bc_penalty_constant = 10.0/nu_0 #100
+dt_fixed = opts.dtout
+dt_init = min(0.1*dt_fixed,0.001)
+nDTout= int(round(T/dt_fixed))
+runCFL = opts.cfl
+
+sedimentDynamics=opts.sedimentDynamics
+
+#----------------------------------------------------
+#  Discretization -- input options
+#----------------------------------------------------
+
+genMesh = True
+movingDomain = False
+applyRedistancing = True
+useOldPETSc = False
+useSuperlu = True
+timeDiscretization = 'be'#'vbdf'#'vbdf'  # 'vbdf', 'be', 'flcbdf'
+spaceOrder = 1
+pspaceOrder = 1
+useHex = False
+useRBLES = 0.0
+useMetrics = 1.0
+applyCorrection = True
+useVF = 1.0
+useOnlyVF = False
+useRANS = opts.useRANS  # 0 -- None
+                        # 1 -- K-Epsilon
+                        # 2 -- K-Omega
+
+
+KILL_PRESSURE_TERM = False
+fixNullSpace_PresInc = True
+INTEGRATE_BY_PARTS_DIV_U_PresInc = True
+CORRECT_VELOCITY = True
+STABILIZATION_TYPE = 0 #0: SUPG, 1: EV via weak residual, 2: EV via strong residual
+
+# Input checks
+if spaceOrder not in [1, 2]:
+    print "INVALID: spaceOrder" + spaceOrder
+    sys.exit()
+
+if useRBLES not in [0.0, 1.0]:
+    print "INVALID: useRBLES" + useRBLES
+    sys.exit()
+
+if useMetrics not in [0.0, 1.0]:
+    print "INVALID: useMetrics"
+    sys.exit()
+
+#  Discretization
+nd = tank.nd
+
+if spaceOrder == 1:
+    hFactor = 1.0
+    if useHex:
+        basis = C0_AffineLinearOnCubeWithNodalBasis
+        elementQuadrature = CubeGaussQuadrature(nd, 2)
+        elementBoundaryQuadrature = CubeGaussQuadrature(nd - 1, 2)
+    else:
+        basis = C0_AffineLinearOnSimplexWithNodalBasis
+        elementQuadrature = SimplexGaussQuadrature(nd, 3)
+        elementBoundaryQuadrature = SimplexGaussQuadrature(nd - 1, 3)
+elif spaceOrder == 2:
+    hFactor = 0.5
+    if useHex:
+        basis = C0_AffineLagrangeOnCubeWithNodalBasis
+        elementQuadrature = CubeGaussQuadrature(nd, 4)
+        elementBoundaryQuadrature = CubeGaussQuadrature(nd - 1, 4)
+    else:
+        basis = C0_AffineQuadraticOnSimplexWithNodalBasis
+        elementQuadrature = SimplexGaussQuadrature(nd, 4)
+        elementBoundaryQuadrature = SimplexGaussQuadrature(nd - 1, 4)
+
+if pspaceOrder == 1:
+    if useHex:
+        pbasis = C0_AffineLinearOnCubeWithNodalBasis
+    else:
+        pbasis = C0_AffineLinearOnSimplexWithNodalBasis
+elif pspaceOrder == 2:
+    if useHex:
+        pbasis = C0_AffineLagrangeOnCubeWithNodalBasis
+    else:
+        pbasis = C0_AffineQuadraticOnSimplexWithNodalBasis
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Numerical parameters
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+ns_forceStrongDirichlet = False
+ns_sed_forceStrongDirichlet = False
+backgroundDiffusionFactor=0.01
+
+if useMetrics:
+    ns_shockCapturingFactor = 0.5
+    ns_lag_shockCapturing = True
+    ns_lag_subgridError = True
+    ns_sed_shockCapturingFactor = 0.5
+    ns_sed_lag_shockCapturing = True
+    ns_sed_lag_subgridError = True
+    ls_shockCapturingFactor = 0.5
+    ls_lag_shockCapturing = True
+    ls_sc_uref = 1.0
+    ls_sc_beta = 1.0
+    vof_shockCapturingFactor = 0.5
+    vof_lag_shockCapturing = True
+    vof_sc_uref = 1.0
+    vof_sc_beta = 1.0
+    vos_shockCapturingFactor = 2. # <------------------------------------- 
+    vos_lag_shockCapturing = True
+    vos_sc_uref = 1.0
+    vos_sc_beta = 1.0
+    rd_shockCapturingFactor = 0.5
+    rd_lag_shockCapturing = False
+    epsFact_vos =opts.epsFact_density
+    epsFact_density = opts.epsFact_density # 1.5
+    epsFact_viscosity = epsFact_curvature = epsFact_vof = epsFact_consrv_heaviside = epsFact_consrv_dirac = epsFact_density
+    epsFact_redistance = 0.33
+    epsFact_consrv_diffusion = opts.epsFact_consrv_diffusion # 0.1
+    redist_Newton = True
+    kappa_shockCapturingFactor = 0.25
+    kappa_lag_shockCapturing = True  #False
+    kappa_sc_uref = 1.0
+    kappa_sc_beta = 1.0
+    dissipation_shockCapturingFactor = 0.25
+    dissipation_lag_shockCapturing = True  #False
+    dissipation_sc_uref = 1.0
+    dissipation_sc_beta = 1.0
+else:
+    ns_shockCapturingFactor = 0.9
+    ns_lag_shockCapturing = True
+    ns_lag_subgridError = True
+    ns_sed_shockCapturingFactor = 0.9
+    ns_sed_lag_shockCapturing = True
+    ns_sed_lag_subgridError = True
+    ls_shockCapturingFactor = 0.9
+    ls_lag_shockCapturing = True
+    ls_sc_uref = 1.0
+    ls_sc_beta = 1.0
+    vof_shockCapturingFactor = 0.9
+    vof_lag_shockCapturing = True
+    vof_sc_uref = 1.0
+    vof_sc_beta = 1.0
+    vos_shockCapturingFactor = 0.9
+    vos_lag_shockCapturing = True
+    vos_sc_uref = 1.0
+    vos_sc_beta = 1.0
+    rd_shockCapturingFactor = 0.9
+    rd_lag_shockCapturing = False
+    epsFact_density = opts.epsFact_density # 1.5
+    epsFact_viscosity = epsFact_curvature = epsFact_vof = epsFact_vos = epsFact_consrv_heaviside = epsFact_consrv_dirac = epsFact_density
+    epsFact_redistance = 0.33
+    epsFact_consrv_diffusion = opts.epsFact_consrv_diffusion # 1.0
+    redist_Newton = False
+    kappa_shockCapturingFactor = 0.9
+    kappa_lag_shockCapturing = True  #False
+    kappa_sc_uref = 1.0
+    kappa_sc_beta = 1.0
+    dissipation_shockCapturingFactor = 0.9
+    dissipation_lag_shockCapturing = True  #False
+    dissipation_sc_uref = 1.0
+    dissipation_sc_beta = 1.0
+
+ns_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+ns_sed_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+vof_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+vos_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+ls_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+rd_nl_atol_res =  max(opts.res, 0.005 * he)
+mcorr_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+kappa_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+dissipation_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+phi_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+pressure_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Turbulence
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+ns_closure = 0  #1-classic smagorinsky, 2-dynamic smagorinsky, 3 -- k-epsilon, 4 -- k-omega
+ns_sed_closure = 0  #1-classic smagorinsky, 2-dynamic smagorinsky, 3 -- k-epsilon, 4 -- k-omega
+if useRANS == 1:
+    ns_closure = 3
+elif useRANS == 2:
+    ns_closure == 4
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Functions for model variables - Initial conditions
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+def signedDistance(x):
+    phi_z = x[1] - waterLine_z
+    return phi_z
+def signedDistance_vos(x):
+    phi_x = x[0] - opts.waterLine_vos_x
+    phi_z = x[1] - opts.waterLine_vos_z
+    if phi_x < 0.0:
+        if phi_z < 0.0:
+            return max(phi_x, phi_z)
+        else:
+            return phi_z
+    else:
+        if phi_z < 0.0:
+            return phi_x
+        else:
+            return sqrt(phi_x ** 2 + phi_z ** 2)
+
+class Suspension_class:
+    def __init__(self):
+        pass
+    def uOfXT(self, x, t=0):
+        phi = signedDistance_vos(x)
+        smoothing = (epsFact_consrv_heaviside)*he/2.
+        Heav = smoothedHeaviside(smoothing, phi)
+        if phi <= -smoothing:
+            return opts.cSed
+        elif -smoothing < phi < smoothing:
+            return opts.cSed * (1.-Heav)
+        else:
+            return 1e-10
+
+def vos_function(x, t=0):
+    phi = signedDistance_vos(x)
+    smoothing = (epsFact_consrv_heaviside)*he/2.
+    Heav = smoothedHeaviside(smoothing, phi)      
+    if phi <= -smoothing:
+        return opts.cSed
+    elif -smoothing < phi < smoothing:
+        return opts.cSed * (1.-Heav)            
+    else:
+        return 1e-10    
+
+
+Suspension = Suspension_class()
+

--- a/2d/sediment/friction_angle_dambrek_sediment/tank_so.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/tank_so.py
@@ -1,0 +1,83 @@
+from proteus import StepControl
+"""
+Split operator module for two-phase flow
+"""
+
+from proteus.default_so import *
+import os
+from proteus import Context
+
+# Create context from main module
+name_so = os.path.basename(__file__)
+if '_so.py' in name_so[-6:]:
+    name = name_so[:-6]
+elif '_so.pyc' in name_so[-7:]:
+    name = name_so[:-7]
+else:
+    raise NameError, 'Split operator module must end with "_so.py"'
+
+try:
+    case = __import__(name)
+    Context.setFromModule(case)
+    ct = Context.get()
+except ImportError:
+    raise ImportError, str(name) + '.py not found'
+
+from proteus import BoundaryConditions
+for BC in ct.domain.bc:
+    BC.getContext()
+
+from proteus.SplitOperator import Sequential_FixedStep_Simple, defaultSystem
+if ct.sedimentDynamics:
+    PINIT_model=9
+    pnList = [("vos_p",               "vos_n"),#0
+              ("vof_p",               "vof_n"),#1
+              ("ls_p",                "ls_n"),#2
+              ("redist_p",            "redist_n"),#3
+              ("ls_consrv_p",         "ls_consrv_n"),#4
+              ("threep_navier_stokes_sed_p", "threep_navier_stokes_sed_n"),#5
+              ("twp_navier_stokes_p", "twp_navier_stokes_n"),#6
+              ("pressureincrement_p", "pressureincrement_n"),#7
+              ("pressure_p", "pressure_n"),#8
+              ("pressureInitial_p", "pressureInitial_n")]#9
+else:
+    PINIT_model=7
+    pnList = [("vof_p",               "vof_n"),#0
+              ("ls_p",                "ls_n"),#1
+              ("redist_p",            "redist_n"),#2
+              ("ls_consrv_p",         "ls_consrv_n"),#3
+              ("twp_navier_stokes_p", "twp_navier_stokes_n"),#4
+              ("pressureincrement_p", "pressureincrement_n"),#5
+              ("pressure_p", "pressure_n"),#6
+              ("pressureInitial_p", "pressureInitial_n")]#7
+
+if ct.useRANS > 0:
+    pnList.append(("kappa_p",
+                   "kappa_n"))
+    pnList.append(("dissipation_p",
+                   "dissipation_n"))
+name = "tank"
+
+#modelSpinUpList = [ct.VOF_model, ct.LS_model, ct.V_model, ct.PINIT_model]
+modelSpinUpList = [PINIT_model]
+
+class Sequential_MinAdaptiveModelStepPS(Sequential_MinAdaptiveModelStep):
+    def __init__(self,modelList,system=defaultSystem,stepExact=True):
+        Sequential_MinAdaptiveModelStep.__init__(self,modelList,system,stepExact)
+        self.modelList = modelList[:len(pnList)-1]
+
+#class Sequential_MinAdaptiveModelStepPS(Sequential_FixedStep):
+#    def __init__(self,modelList,system=defaultSystem,stepExact=True):
+#        Sequential_FixedStep.__init__(self,modelList,system,stepExact)
+#        self.modelList = modelList[:len(pnList)-1]
+#dt_system_fixed = ct.dt_fixed
+
+systemStepControllerType = Sequential_MinAdaptiveModelStepPS
+
+needEBQ_GLOBAL = False
+needEBQ = False
+
+tnList = [0.0,ct.dt_init]+[ct.dt_init+i*ct.dt_fixed for i in range(1,ct.nDTout+1)]
+
+info = open("TimeList.txt","w")
+#archiveFlag = ArchiveFlags.EVERY_SEQUENCE_STEP

--- a/2d/sediment/friction_angle_dambrek_sediment/threep_navier_stokes_sed_n.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/threep_navier_stokes_sed_n.py
@@ -1,0 +1,72 @@
+from proteus import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+from threep_navier_stokes_sed_p import *
+from tank import *
+
+if timeDiscretization=='vbdf':
+    timeIntegration = VBDF
+    timeOrder=2
+    stepController  = Min_dt_cfl_controller
+elif timeDiscretization=='flcbdf':
+    timeIntegration = FLCBDF
+    #stepController = FLCBDF_controller_sys
+    stepController  = Min_dt_cfl_controller
+    time_tol = 10.0*ns_sed_nl_atol_res
+    atol_u = {0:time_tol,1:time_tol}
+    rtol_u = {0:time_tol,1:time_tol}
+else:
+    timeIntegration = BackwardEuler_cfl
+    stepController  = Min_dt_cfl_controller
+
+femSpaces = {0:basis,
+	     1:basis}
+
+massLumping       = False
+numericalFluxType = None
+conservativeFlux  = None
+
+numericalFluxType = RANS3PSed.NumericalFlux
+subgridError = RANS3PSed.SubgridError(coefficients,nd,lag=ns_sed_lag_subgridError,hFactor=hFactor)
+shockCapturing = RANS3PSed.ShockCapturing(coefficients,nd,ns_sed_shockCapturingFactor,lag=ns_sed_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+
+linearSmoother    = None
+
+matrix = SparseMatrix
+
+if useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'rans3p_sed_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest             = 'r-true'
+
+tolFac = 0.0
+linTolFac = 0.01
+l_atol_res = 0.01*ns_sed_nl_atol_res
+nl_atol_res = ns_sed_nl_atol_res
+useEisenstatWalker = False
+maxNonlinearIts = 50
+maxLineSearches = 0
+conservativeFlux = {0:'point-eval'}
+#conservativeFlux = {0:'pwl-bdm-opt'}
+#auxiliaryVariables=[pointGauges,lineGauges]
+auxiliaryVariables = ct.domain.auxiliaryVariables['thp']+[ct.vs_output]

--- a/2d/sediment/friction_angle_dambrek_sediment/threep_navier_stokes_sed_p.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/threep_navier_stokes_sed_p.py
@@ -1,0 +1,118 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import RANS3PSed
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = RANS3PSed.LevelModel
+
+if ct.sedimentDynamics:
+    VOS_model=0
+    VOF_model=1
+    LS_model=2
+    RD_model=3
+    MCORR_model=4
+    SED_model=5
+    V_model=6
+    PINC_model=7
+    PRESSURE_model=8
+    PINIT_model=9
+else:
+    VOS_model=None
+    SED_model=None
+    VOF_model=0
+    LS_model=1
+    RD_model=2
+    MCORR_model=3
+    V_model=4
+    PINC_model=5
+    PRESSURE_model=6
+    PINIT_model=7
+
+if useOnlyVF:
+    LS_model = None
+else:
+    LS_model = 2
+if useRANS >= 1:
+    Closure_0_model = 5; Closure_1_model=6
+    if useOnlyVF:
+        Closure_0_model=2; Closure_1_model=3
+    if movingDomain:
+        Closure_0_model += 1; Closure_1_model += 1
+else:
+    Closure_0_model = None
+    Closure_1_model = None
+
+coefficients = RANS3PSed.Coefficients(epsFact=epsFact_viscosity,
+                                      sigma=0.0,
+                                      rho_0 = rho_0,
+                                      nu_0 = nu_0, 
+                                      rho_1 = rho_1,
+                                      nu_1 = nu_1,
+                                      rho_s = rho_s,
+                                      g=g,
+                                      nd=nd,
+                                      ME_model=SED_model,
+                                      PRESSURE_model=PRESSURE_model,
+                                      FLUID_model=V_model,
+                                      VOS_model=VOS_model,
+                                      VOF_model=VOF_model,
+                                      LS_model=LS_model,
+                                      Closure_0_model=Closure_0_model,
+                                      Closure_1_model=Closure_1_model,
+                                      epsFact_density=epsFact_density,
+                                      stokes=False,
+                                      useVF=True,
+                                      useRBLES=useRBLES,
+                                      useMetrics=useMetrics,
+                                      eb_adjoint_sigma=1.0,
+                                      eb_penalty_constant=weak_bc_penalty_constant,
+                                      forceStrongDirichlet=ns_forceStrongDirichlet,
+                                      turbulenceClosureModel=ns_closure,
+                                      movingDomain=movingDomain,
+                                      dragAlpha=dragAlpha,
+                                      PSTAB=ct.opts.PSTAB,
+                                    aDarcy = sedClosure.aDarcy,
+                                    betaForch = sedClosure.betaForch,
+                                    grain = sedClosure.grain,
+                                    packFraction = sedClosure.packFraction,
+                                    maxFraction = sedClosure.maxFraction,
+                                    frFraction = sedClosure.frFraction,
+                                    sigmaC = sedClosure.sigmaC,
+                                    C3e = sedClosure.C3e,
+                                    C4e = sedClosure.C4e,
+                                    eR = sedClosure.eR,
+                                    fContact = sedClosure.fContact,
+                                    mContact = sedClosure.mContact,
+                                    nContact = sedClosure.nContact,
+                                    angFriction = sedClosure.angFriction,
+                                    vos_function = ct.vos_function,
+                                    staticSediment = False,
+                                    vos_limiter = ct.sedClosure.vos_limiter,
+                                    mu_fr_limiter = ct.sedClosure.mu_fr_limiter,
+                                    )
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].us_dirichlet.init_cython(),
+                       1: lambda x, flag: domain.bc[flag].vs_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].us_advective.init_cython(),
+                                   1: lambda x, flag: domain.bc[flag].vs_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {0: lambda x, flag: domain.bc[flag].us_diffusive.init_cython()},
+                                   1: {1: lambda x, flag: domain.bc[flag].vs_diffusive.init_cython()}}
+
+if nd == 3:
+    dirichletConditions[2] = lambda x, flag: domain.bc[flag].ws_dirichlet.init_cython()
+    advectiveFluxBoundaryConditions[2] = lambda x, flag: domain.bc[flag].ws_advective.init_cython()
+    diffusiveFluxBoundaryConditions[2] = {2: lambda x, flag: domain.bc[flag].ws_diffusive.init_cython()}
+
+class AtRest:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+initialConditions = {0:AtRest(),
+                     1:AtRest()}

--- a/2d/sediment/friction_angle_dambrek_sediment/twp_navier_stokes_n.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/twp_navier_stokes_n.py
@@ -1,0 +1,74 @@
+from proteus import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+from twp_navier_stokes_p import *
+from tank import *
+
+if timeDiscretization=='vbdf':
+    timeIntegration = VBDF
+    timeOrder=2
+    stepController  = Min_dt_cfl_controller
+elif timeDiscretization=='flcbdf':
+    timeIntegration = FLCBDF
+    #stepController = FLCBDF_controller_sys
+    stepController  = Min_dt_cfl_controller
+    time_tol = 10.0*ns_nl_atol_res
+    atol_u = {0:time_tol,1:time_tol}
+    rtol_u = {0:time_tol,1:time_tol}
+else:
+    timeIntegration = BackwardEuler_cfl
+    stepController  = Min_dt_cfl_controller
+
+femSpaces = {0:basis,
+	     1:basis}
+#femSpaces = {0:C0_AffineQuadraticOnSimplexWithNodalBasis,
+#             1:C0_AffineQuadraticOnSimplexWithNodalBasis}
+
+massLumping       = False
+numericalFluxType = None
+conservativeFlux  = None
+
+numericalFluxType = RANS3PF.NumericalFlux
+subgridError = RANS3PF.SubgridError(coefficients,nd,lag=ns_lag_subgridError,hFactor=hFactor)
+shockCapturing = RANS3PF.ShockCapturing(coefficients,nd,ns_shockCapturingFactor,lag=ns_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+
+linearSmoother    = None #SimpleNavierStokes2D
+
+matrix = SparseMatrix
+
+if useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'rans2p_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest             = 'r-true'
+
+tolFac = 0.0
+linTolFac = 0.01
+l_atol_res = 0.01*ns_nl_atol_res
+nl_atol_res = ns_nl_atol_res
+useEisenstatWalker = False
+maxNonlinearIts = 50
+maxLineSearches = 0
+conservativeFlux = {0:'point-eval'}
+#conservativeFlux = {0:'pwl-bdm-opt'}
+#auxiliaryVariables=[pointGauges,lineGauges]
+auxiliaryVariables = ct.domain.auxiliaryVariables['twp']+[ct.v_output]

--- a/2d/sediment/friction_angle_dambrek_sediment/twp_navier_stokes_p.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/twp_navier_stokes_p.py
@@ -1,0 +1,115 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import RANS3PF
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = RANS3PF.LevelModel
+
+if ct.sedimentDynamics:
+    VOS_model=0
+    VOF_model=1
+    LS_model=2
+    RD_model=3
+    MCORR_model=4
+    SED_model=5
+    V_model=6
+    PINC_model=7
+    PRESSURE_model=8
+    PINIT_model=9
+else:
+    VOS_model=None
+    SED_model=None
+    VOF_model=0
+    LS_model=1
+    RD_model=2
+    MCORR_model=3
+    V_model=4
+    PINC_model=5
+    PRESSURE_model=6
+    PINIT_model=7
+if useOnlyVF:
+    LS_model = None
+else:
+    LS_model = 2
+if useRANS >= 1:
+    Closure_0_model = 5; Closure_1_model=6
+    if useOnlyVF:
+        Closure_0_model=2; Closure_1_model=3
+    if movingDomain:
+        Closure_0_model += 1; Closure_1_model += 1
+else:
+    Closure_0_model = None
+    Closure_1_model = None
+
+coefficients = RANS3PF.Coefficients(epsFact=epsFact_viscosity,
+                                    sigma=0.0,
+                                    rho_0 = rho_0,
+                                    nu_0 = nu_0,
+                                    rho_1 = rho_1,
+                                    nu_1 = nu_1,
+                                    g=g,
+                                    nd=nd,
+                                    ME_model=V_model,
+                                    PRESSURE_model=PRESSURE_model,
+                                    SED_model=SED_model,
+                                    VOF_model=VOF_model,
+                                    VOS_model=VOS_model,
+                                    LS_model=LS_model,
+                                    Closure_0_model=Closure_0_model,
+                                    Closure_1_model=Closure_1_model,
+                                    epsFact_density=epsFact_density,
+                                    stokes=False,
+                                    useVF=useVF,
+                                    useRBLES=useRBLES,
+                                    useMetrics=useMetrics,
+                                    eb_adjoint_sigma=1.0,
+                                    eb_penalty_constant=weak_bc_penalty_constant,
+                                    forceStrongDirichlet=ns_forceStrongDirichlet,
+                                    turbulenceClosureModel=ns_closure,
+                                    movingDomain=movingDomain,
+                                    dragAlpha=dragAlpha,
+                                    PSTAB=ct.opts.PSTAB,
+                                    aDarcy = sedClosure.aDarcy,
+                                    betaForch = sedClosure.betaForch,
+                                    grain = sedClosure.grain,
+                                    packFraction = sedClosure.packFraction,
+                                    maxFraction = sedClosure.maxFraction,
+                                    frFraction = sedClosure.frFraction,
+                                    sigmaC = sedClosure.sigmaC,
+                                    C3e = sedClosure.C3e,
+                                    C4e = sedClosure.C4e,
+                                    eR = sedClosure.eR,
+                                    fContact = sedClosure.fContact,
+                                    mContact = sedClosure.mContact,
+                                    nContact = sedClosure.nContact,
+                                    angFriction = sedClosure.angFriction,
+                                    vos_function = ct.vos_function,
+                                    vos_limiter = ct.sedClosure.vos_limiter,
+                                    mu_fr_limiter = ct.sedClosure.mu_fr_limiter,
+                                    )
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].u_dirichlet.init_cython(),
+                       1: lambda x, flag: domain.bc[flag].v_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].u_advective.init_cython(),
+                                   1: lambda x, flag: domain.bc[flag].v_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {0: lambda x, flag: domain.bc[flag].u_diffusive.init_cython()},
+                                   1: {1: lambda x, flag: domain.bc[flag].v_diffusive.init_cython()}}
+
+if nd == 3:
+    dirichletConditions[2] = lambda x, flag: domain.bc[flag].w_dirichlet.init_cython()
+    advectiveFluxBoundaryConditions[2] = lambda x, flag: domain.bc[flag].w_advective.init_cython()
+    diffusiveFluxBoundaryConditions[2] = {2: lambda x, flag: domain.bc[flag].w_diffusive.init_cython()}
+
+class AtRest:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+initialConditions = {0:AtRest(),
+                     1:AtRest()}

--- a/2d/sediment/friction_angle_dambrek_sediment/vof_n.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/vof_n.py
@@ -1,0 +1,77 @@
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import vof_p as physics
+from proteus.mprans import VOF3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+# time stepping
+runCFL = ct.runCFL
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_controller
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = VOF3P.NumericalFlux
+conservativeFlux  = None
+subgridError      = VOF3P.SubgridError(coefficients=physics.coefficients,nd=nd)
+shockCapturing    = VOF3P.ShockCapturing(physics.coefficients,nd,shockCapturingFactor=ct.vof_shockCapturingFactor,lag=ct.vof_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'vof_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'r-true'
+
+tolFac      = 0.0
+nl_atol_res = ct.vof_nl_atol_res
+
+linTolFac   = 0.0
+l_atol_res = 0.1*ct.vof_nl_atol_res
+
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+
+auxiliaryVariables = ct.domain.auxiliaryVariables['vof']

--- a/2d/sediment/friction_angle_dambrek_sediment/vof_p.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/vof_p.py
@@ -1,0 +1,52 @@
+from proteus.default_p import *
+from proteus.ctransportCoefficients import smoothedHeaviside
+from proteus.mprans import VOF3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+LevelModelType = VOF3P.LevelModel
+
+if ct.sedimentDynamics:
+    LS_model=2
+    V_model=6
+    RD_model=3
+    VOF_model=1
+    VOS_model=0
+else:
+    VOS_model=None
+    VOF_model=0
+    LS_model=1
+    RD_model=2
+    V_model=4
+
+coefficients = VOF3P.Coefficients(LS_model=LS_model,
+                                  V_model=V_model,
+                                  RD_model=RD_model,
+                                  ME_model=VOF_model,
+                                  VOS_model=VOS_model,
+                                  checkMass=True,
+                                  useMetrics=ct.useMetrics,
+                                  epsFact=ct.epsFact_vof,
+                                  sc_uref=ct.vof_sc_uref,
+                                  sc_beta=ct.vof_sc_beta,
+                                  movingDomain=ct.movingDomain)
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].vof_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].vof_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {}}
+
+class VF_IC:
+    def uOfXT(self, x, t):
+        return smoothedHeaviside(ct.epsFact_consrv_heaviside*mesh.he,x[nd-1]-ct.waterLevel)
+
+initialConditions = {0: VF_IC()}

--- a/2d/sediment/friction_angle_dambrek_sediment/vos_n.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/vos_n.py
@@ -1,0 +1,81 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import vof_p as physics
+from proteus import Context
+from proteus.mprans import VOS3P
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+# time stepping
+runCFL = ct.runCFL
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_controller
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = VOS3P.NumericalFlux
+conservativeFlux  = None
+subgridError      = VOS3P.SubgridError(coefficients=physics.coefficients,nd=nd)
+shockCapturing    = VOS3P.ShockCapturing(physics.coefficients,nd,shockCapturingFactor=ct.vos_shockCapturingFactor,lag=ct.vos_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'vos_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'r-true'
+
+tolFac      = 0.0
+nl_atol_res = ct.vos_nl_atol_res
+
+linTolFac   = 0.0
+l_atol_res = 0.1*ct.vos_nl_atol_res
+
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+
+#auxiliaryVariables = ct.domain.auxiliaryVariables['vos']
+auxiliaryVariables = ct.domain.auxiliaryVariables['vos']+[ct.vos_output]

--- a/2d/sediment/friction_angle_dambrek_sediment/vos_p.py
+++ b/2d/sediment/friction_angle_dambrek_sediment/vos_p.py
@@ -1,0 +1,44 @@
+from proteus import StepControl
+from proteus.default_p import *
+from proteus.ctransportCoefficients import smoothedHeaviside
+from proteus.mprans import VOS3P
+from proteus import Context
+from proteus import *
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+LevelModelType = VOS3P.LevelModel
+
+
+if ct.sedimentDynamics:
+    V_model=6
+    SED_model=5
+else:
+    V_model=4
+    SED_model=None
+
+coefficients = VOS3P.Coefficients(LS_model=None,
+                                  V_model=V_model,
+                                  SED_model=SED_model,
+                                  RD_model=None,
+                                  ME_model=0,
+                                  checkMass=False,
+                                  useMetrics=ct.useMetrics,
+                                  epsFact=ct.epsFact_vos,
+                                  sc_uref=ct.vos_sc_uref,
+                                  sc_beta=ct.vos_sc_beta,
+                                  movingDomain=ct.movingDomain,
+                                  vos_function=ct.vos_function,
+                                  )
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].vos_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].vos_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {}}
+
+
+initialConditions  = {0:ct.Suspension}

--- a/2d/sediment/group_sediment/TimeSeriesPlot.py
+++ b/2d/sediment/group_sediment/TimeSeriesPlot.py
@@ -1,0 +1,54 @@
+from proteus import StepControl
+#from scipy import *
+from pylab import *
+from numpy import *
+import collections as cll
+
+filename='pointGauge_pressure.txt'
+headerline = 0
+
+
+# Read header info 
+
+fid = open(filename,'r')
+prdata=loadtxt(fid,skiprows=headerline)
+fid.seek(0)
+D = fid.readlines()
+header = D[:headerline]
+n=len(D)
+
+a = array(zeros((int(n),5)))
+step = zeros(int(n),float)
+for i in range (int(n)):
+ a[i,:]=D[i].split()
+ step[i]=i
+
+a = array(a,dtype=float32)
+
+y = zeros(int(n),float)
+
+y[:] = a[:,2]
+
+
+
+
+
+
+#j=str(2)
+
+fig1 = figure(1)
+fig1.add_subplot(1,1,1)
+plot(step[:],y[:],"k",lw=2)
+
+##xlim(80,90)
+##ylim(-0.05,0.05)
+
+grid()
+#title('Surface elevation at $x=$' + str(probex[int(j)])+'m')
+title('Point gauge pressure evolution')
+xlabel('Step')
+ylabel('Pressure')
+
+show()
+savefig('plottrial.pdf')
+savefig('plottrial.png',dpi=100)

--- a/2d/sediment/group_sediment/dissipation_n.py
+++ b/2d/sediment/group_sediment/dissipation_n.py
@@ -1,0 +1,59 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import dissipation_p as physics
+from proteus import Context
+from proteus.mprans import Dissipation
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+triangleOptions = mesh.triangleOptions
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_cfl_controller
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = Dissipation.NumericalFlux
+conservativeFlux  = None
+subgridError      = Dissipation.SubgridError(coefficients=physics.coefficients,nd=ct.nd)
+shockCapturing    = Dissipation.ShockCapturing(physics.coefficients,ct.nd,shockCapturingFactor=ct.dissipation_shockCapturingFactor,
+                                         lag=ct.dissipation_lag_shockCapturing)
+
+fullNewtonFlag  = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+#printNonlinearSolverInfo = True
+matrix = SparseMatrix
+if not ct.useOldPETSc and not ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+else:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'dissipation_'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'rits'
+
+tolFac = 0.0
+linTolFac =0.0
+l_atol_res = 0.001*ct.dissipation_nl_atol_res
+nl_atol_res = ct.dissipation_nl_atol_res
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+

--- a/2d/sediment/group_sediment/dissipation_p.py
+++ b/2d/sediment/group_sediment/dissipation_p.py
@@ -1,0 +1,58 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import Dissipation
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = Dissipation.LevelModel
+if useOnlyVF:
+    RD_model = None
+    LS_model = None
+    dissipation_model = 3
+    ME_model = 2
+else:
+    RD_model = 3
+    LS_model = 2
+    ME_model = 6
+    kappa_model = 5
+
+dissipation_model_flag = 1
+if ct.useRANS >= 2:
+    dissipation_model_flag=2
+coefficients = Dissipation.Coefficients(V_model=0+int(ct.movingDomain),
+                                        ME_model=ME_model+int(ct.movingDomain),
+                                        LS_model=LS_model+int(ct.movingDomain),
+                                        RD_model=RD_model+int(ct.movingDomain),
+                                        kappa_model=kappa_model+int(ct.movingDomain),
+                                        dissipation_model_flag=dissipation_model_flag+int(ct.movingDomain),#1 -- K-epsilon, 2 -- K-omega
+                                  useMetrics=useMetrics,
+                                  rho_0=rho_0,nu_0=nu_0,
+                                  rho_1=rho_1,nu_1=nu_1,
+                                  g=g,
+                                  c_mu=ct.opts.Cmu,sigma_e=ct.opts.sigma_e,
+                                  sc_uref=dissipation_sc_uref,
+                                  sc_beta=dissipation_sc_beta)
+
+kInflow=ct.kInflow
+
+dissipationInflow=ct.dissipationInflow
+
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].dissipation_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].dissipation_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {},
+                                   1: {1: lambda x, flag: domain.bc[flag].dissipation_diffusive.init_cython()},
+                                  }
+
+ 
+class ConstantIC:
+    def __init__(self,cval=0.0):
+        self.cval=cval
+    def uOfXT(self,x,t):
+        return self.cval
+
+initialConditions  = {0:ConstantIC(cval=dissipationInflow)}

--- a/2d/sediment/group_sediment/eddy_viscosity_view_batch.py
+++ b/2d/sediment/group_sediment/eddy_viscosity_view_batch.py
@@ -1,0 +1,7 @@
+from proteus import StepControl
+#0 is Navier-Stokes flow model
+simFlagsList[0]['storeQuantities']= ['simulationData',"q:'eddy_viscosity'"]
+simFlagsList[0]['storeTimes']     = ['All']
+#
+start
+quit

--- a/2d/sediment/group_sediment/kappa_n.py
+++ b/2d/sediment/group_sediment/kappa_n.py
@@ -1,0 +1,61 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import kappa_p as physics
+from proteus import Context
+from proteus.mprans import Kappa
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+triangleOptions = mesh.triangleOptions
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_cfl_controller
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = Kappa.NumericalFlux
+conservativeFlux  = None
+subgridError      = Kappa.SubgridError(coefficients=physics.coefficients,nd=ct.nd)
+shockCapturing    = Kappa.ShockCapturing(physics.coefficients,ct.nd,shockCapturingFactor=ct.kappa_shockCapturingFactor,
+                                         lag=ct.kappa_lag_shockCapturing)
+
+fullNewtonFlag  = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+#printNonlinearSolverInfo = True
+matrix = SparseMatrix
+if not ct.useOldPETSc and not ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+else:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'kappa_'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'rits'
+
+tolFac = 0.0
+linTolFac =0.0
+l_atol_res = 0.001*ct.kappa_nl_atol_res
+nl_atol_res = ct.kappa_nl_atol_res
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+
+auxiliaryVariables = ct.domain.auxiliaryVariables['kappa']
+

--- a/2d/sediment/group_sediment/kappa_p.py
+++ b/2d/sediment/group_sediment/kappa_p.py
@@ -1,0 +1,57 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import Kappa
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = Kappa.LevelModel
+if useOnlyVF:
+    RD_model = None
+    LS_model = None
+    dissipation_model = 3
+    ME_model = 2
+else:
+    RD_model = 3
+    LS_model = 2
+    ME_model = 5
+    dissipation_model = 6
+
+dissipation_model_flag = 1
+if ct.useRANS >= 2:
+    dissipation_model_flag=2
+
+coefficients = Kappa.Coefficients(V_model=0+int(ct.movingDomain),
+                                  ME_model=ME_model+int(ct.movingDomain),
+                                  LS_model=LS_model+int(ct.movingDomain),
+                                  RD_model=RD_model+int(ct.movingDomain),
+                                  dissipation_model=dissipation_model+int(ct.movingDomain),
+                                  dissipation_model_flag=dissipation_model_flag+int(ct.movingDomain),#1 -- K-epsilon, 2 -- K-omega
+                                  useMetrics=useMetrics,
+                                  rho_0=rho_0,nu_0=nu_0,
+                                  rho_1=rho_1,nu_1=nu_1,
+                                  g=g,
+                                  c_mu=ct.opts.Cmu,sigma_k=ct.opts.sigma_k, 
+                                  sc_uref=kappa_sc_uref,
+                                  sc_beta=kappa_sc_beta)
+
+kInflow=ct.kInflow
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].k_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].k_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {},
+                                   1: {1: lambda x, flag: domain.bc[flag].k_diffusive.init_cython()},
+                                  }
+
+
+class ConstantIC:
+    def __init__(self,cval=0.0):
+        self.cval=cval
+    def uOfXT(self,x,t):
+        return self.cval
+
+   
+initialConditions  = {0:ConstantIC(cval=kInflow)}

--- a/2d/sediment/group_sediment/ls_consrv_n.py
+++ b/2d/sediment/group_sediment/ls_consrv_n.py
@@ -1,0 +1,78 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools,
+                     NumericalFlux)
+import ls_consrv_p as physics
+from proteus import Context
+from proteus.mprans.MCorr3P import DummyNewton
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+#time stepping
+runCFL = ct.runCFL
+timeIntegrator  = TimeIntegration.ForwardIntegrator
+timeIntegration = TimeIntegration.NoIntegration
+
+#mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0:ct.basis}
+
+subgridError      = None
+massLumping       = False
+numericalFluxType = ct.DoNothing
+conservativeFlux  = None
+shockCapturing    = None
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+#multilevelNonlinearSolver = DummyNewton
+#levelNonlinearSolver      = DummyNewton
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'mcorr_'
+nonlinearSolverConvergenceTest  = 'rits'
+levelNonlinearSolverConvergenceTest  = 'rits'
+linearSolverConvergenceTest  = 'r-true'
+
+tolFac = 0.0
+linTolFac = 0.01
+l_atol_res = 0.01*ct.mcorr_nl_atol_res
+nl_atol_res = ct.mcorr_nl_atol_res
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0

--- a/2d/sediment/group_sediment/ls_consrv_p.py
+++ b/2d/sediment/group_sediment/ls_consrv_p.py
@@ -1,0 +1,53 @@
+from proteus import StepControl
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import MCorr3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+
+LevelModelType = MCorr3P.LevelModel
+
+if ct.sedimentDynamics:
+    VOS_model=0
+    VOF_model=1
+    LS_model=2
+    MCORR_model=4
+    V_model=6
+else:
+    VOS_model=None
+    VOF_model=0
+    LS_model=1
+    MCORR_model=3
+    V_model=4
+
+coefficients = MCorr3P.Coefficients(LS_model=LS_model,
+                                    V_model=V_model,
+                                    ME_model=MCORR_model,
+                                    VOF_model=VOF_model,
+                                    VOS_model=VOS_model,
+                                    applyCorrection=ct.applyCorrection,
+                                    nd=nd,
+                                    checkMass=False,
+                                    useMetrics=ct.useMetrics,
+                                    epsFactHeaviside=ct.epsFact_consrv_heaviside,
+                                    epsFactDirac=ct.epsFact_consrv_dirac,
+                                    epsFactDiffusion=ct.epsFact_consrv_diffusion)
+
+class zero_phi:
+    def __init__(self):
+        pass
+    def uOfX(self,X):
+        return 0.0
+    def uOfXT(self,X,t):
+        return 0.0
+
+initialConditions  = {0:zero_phi()}

--- a/2d/sediment/group_sediment/ls_n.py
+++ b/2d/sediment/group_sediment/ls_n.py
@@ -1,0 +1,78 @@
+from proteus import StepControl
+from proteus.default_n import *
+import ls_p as physics
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+from proteus.mprans import NCLS3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+coefficients = physics.coefficients
+
+# time stepping
+runCFL = ct.runCFL
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_controller
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0: ct.basis}
+
+massLumping       = False
+conservativeFlux  = None
+numericalFluxType = NCLS3P.NumericalFlux
+subgridError      = NCLS3P.SubgridError(coefficients,nd)
+shockCapturing    = NCLS3P.ShockCapturing(coefficients,nd,shockCapturingFactor=ct.ls_shockCapturingFactor,lag=ct.ls_lag_shockCapturing)
+
+fullNewtonFlag  = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'ncls_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'r-true'
+
+tolFac = 0.0
+nl_atol_res = ct.ls_nl_atol_res
+linTolFac = 0.0
+l_atol_res = 0.1*ct.ls_nl_atol_res
+
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+
+auxiliaryVariables = ct.domain.auxiliaryVariables['ls']

--- a/2d/sediment/group_sediment/ls_p.py
+++ b/2d/sediment/group_sediment/ls_p.py
@@ -1,0 +1,48 @@
+from proteus import StepControl
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import NCLS3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+
+LevelModelType = NCLS3P.LevelModel
+
+if ct.sedimentDynamics:
+    LS_model=2
+    RD_model=3
+    V_model=6
+else:
+    LS_model=1
+    RD_model=2
+    V_model=4
+
+coefficients = NCLS3P.Coefficients(V_model=V_model,
+                                   RD_model=RD_model,
+                                   ME_model=LS_model,
+                                   checkMass=False,
+                                   useMetrics=ct.useMetrics,
+                                   epsFact=ct.epsFact_consrv_heaviside,
+                                   sc_uref=ct.ls_sc_uref,
+                                   sc_beta=ct.ls_sc_beta,
+                                   movingDomain=ct.movingDomain)
+
+dirichletConditions = {0: lambda x, flag: None}
+
+advectiveFluxBoundaryConditions = {}
+
+diffusiveFluxBoundaryConditions = {0: {}}
+
+class PHI_IC:
+    def uOfXT(self, x, t):
+        return x[nd-1] - ct.waterLevel
+
+initialConditions = {0: PHI_IC()}

--- a/2d/sediment/group_sediment/pressureInitial_n.py
+++ b/2d/sediment/group_sediment/pressureInitial_n.py
@@ -1,0 +1,54 @@
+from proteus import *
+from proteus.default_n import *
+from pressureInitial_p import *
+
+
+mesh = domain.MeshOptions
+triangleOptions = triangleOptions
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+
+femSpaces = {0:ct.pbasis}
+
+stepController=FixedStep
+
+#numericalFluxType = NumericalFlux.ConstantAdvection_Diffusion_SIPG_exterior #weak boundary conditions (upwind ?)
+matrix = LinearAlgebraTools.SparseMatrix
+
+#linearSmoother    = LinearSolvers.NavierStokesPressureCorrection # pure neumann laplacian solver
+#multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+#levelLinearSolver = LinearSolvers.KSP_petsc4py
+#linearSmoother    = None
+#multilevelLinearSolver = LinearSolvers.LU
+#levelLinearSolver      = LinearSolvers.LU
+numericalFluxType = NumericalFlux.ConstantAdvection_exterior
+#numericalFluxType = NumericalFlux
+
+linear_solver_options_prefix = 'pinit_'
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+else:
+    multilevelLinearSolver = KSP_petsc4py
+    levelLinearSolver      = KSP_petsc4py
+    parallelPartitioningType    = parallelPartitioningType
+    nLayersOfOverlapForParallel = nLayersOfOverlapForParallel
+    nonlinearSmoother = None
+    linearSmoother    = None
+
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+#linear solve rtolerance
+
+linTolFac = 0.0
+l_atol_res = 0.01*ct.phi_nl_atol_res
+tolFac = 0.0
+nl_atol_res = ct.phi_nl_atol_res
+nonlinearSolverConvergenceTest = 'r'
+levelNonlinearSolverConvergenceTest = 'r'
+linearSolverConvergenceTest             = 'r-true'
+maxLineSearches=0
+periodicDirichletConditions=None
+
+conservativeFlux=None

--- a/2d/sediment/group_sediment/pressureInitial_p.py
+++ b/2d/sediment/group_sediment/pressureInitial_p.py
@@ -1,0 +1,52 @@
+from math import *
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import PresInit
+from proteus import Context
+from tank import *
+
+ct = Context.get()
+name = "pressureInitial"
+
+if ct.sedimentDynamics:
+    V_model=6
+    PRESSURE_model=8
+    PINIT_model=9
+else:
+    V_model=4
+    PRESSURE_model=6
+    PINIT_model=7
+
+coefficients=PresInit.Coefficients(nd=nd,
+                                   modelIndex=PINIT_model,
+                                   fluidModelIndex=V_model,
+                                   pressureModelIndex=PRESSURE_model)
+
+#pressure increment should be zero on any pressure dirichlet boundaries
+
+#the advectiveFlux should be zero on any no-flow  boundaries
+
+
+class getIBC_pInit:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+class PerturbedSurface_p:
+    def __init__(self,waterLevel):
+        self.waterLevel=waterLevel
+    def uOfXT(self,x,t):
+        self.vos = ct.vos_function(x)
+        self.rho_a = rho_1#(1.-self.vos)*rho_1 + (self.vos)*ct.rho_s
+        self.rho_w = rho_0#(1.-self.vos)*rho_0 + (self.vos)*ct.rho_s
+        if signedDistance(x) < 0:
+            return -(L[1] - self.waterLevel)*self.rho_a*g[1] - (self.waterLevel - x[1])*self.rho_w*g[1]
+        else:
+            return -(L[1] - x[1])*self.rho_a*g[1]
+
+initialConditions = {0:PerturbedSurface_p(waterLine_z)} #getIBC_pInit()}
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].pInit_dirichlet.init_cython()}
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].pInit_advective.init_cython()}
+diffusiveFluxBoundaryConditions = {0:{0: lambda x, flag: domain.bc[flag].pInit_diffusive.init_cython()}}

--- a/2d/sediment/group_sediment/pressure_n.py
+++ b/2d/sediment/group_sediment/pressure_n.py
@@ -1,0 +1,53 @@
+from proteus import *
+from proteus.default_n import *
+from pressure_p import *
+
+
+mesh = domain.MeshOptions
+triangleOptions = triangleOptions
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+
+femSpaces = {0:ct.pbasis}
+
+
+# stepController  = StepControl.Min_dt_cfl_controller
+# runCFL= 0.99
+# runCFL= 0.5
+
+stepController=FixedStep
+
+#matrix type
+numericalFluxType = NumericalFlux.ConstantAdvection_exterior
+#numericalFluxType = NumericalFlux
+matrix = LinearAlgebraTools.SparseMatrix
+
+linear_solver_options_prefix = 'pressure_'
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+else:
+    multilevelLinearSolver = KSP_petsc4py
+    levelLinearSolver      = KSP_petsc4py
+    parallelPartitioningType    = parallelPartitioningType
+    nLayersOfOverlapForParallel = nLayersOfOverlapForParallel
+    nonlinearSmoother = None
+    linearSmoother    = None
+
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+#linear solve rtolerance
+
+linTolFac = 0.0
+l_atol_res = 0.1*ct.pressure_nl_atol_res
+tolFac = 0.0
+nl_atol_res = ct.pressure_nl_atol_res
+maxLineSearches = 0
+nonlinearSolverConvergenceTest      = 'r'
+levelNonlinearSolverConvergenceTest = 'r'
+linearSolverConvergenceTest         = 'r-true'
+
+periodicDirichletConditions=None
+
+conservativeFlux=None

--- a/2d/sediment/group_sediment/pressure_p.py
+++ b/2d/sediment/group_sediment/pressure_p.py
@@ -1,0 +1,44 @@
+from math import *
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import Pres
+from proteus import Context
+from tank import *
+
+ct = Context.get()
+name = "pressure"
+
+LevelModelType = Pres.LevelModel
+
+if ct.sedimentDynamics:
+    V_model=6
+    PINC_model=7
+    PRESSURE_model=8
+
+else:
+    V_model=4
+    PINC_model=5
+    PRESSURE_model=6
+
+coefficients=Pres.Coefficients(modelIndex=PRESSURE_model,
+                               fluidModelIndex=V_model,
+                               pressureIncrementModelIndex=PINC_model,
+                               useRotationalForm=True)
+
+
+class getIBC_p:
+    def __init__(self,waterLevel):
+        self.waterLevel=waterLevel
+    def uOfXT(self,x,t):
+        self.vos = ct.vos_function(x)
+        self.rho_a = rho_1#(1.-self.vos)*rho_1 + (self.vos)*ct.rho_s
+        self.rho_w = rho_0#(1.-self.vos)*rho_0 + (self.vos)*ct.rho_s
+        if signedDistance(x) < 0:
+            return -(L[1] - self.waterLevel)*self.rho_a*g[1] - (self.waterLevel - x[1])*self.rho_w*g[1]
+        else:
+            return -(L[1] - x[1])*self.rho_a*g[1]
+
+initialConditions = {0:getIBC_p(waterLine_z)}
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].p_dirichlet.init_cython() } # pressure bc are explicitly set
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].p_advective.init_cython()}

--- a/2d/sediment/group_sediment/pressureincrement_n.py
+++ b/2d/sediment/group_sediment/pressureincrement_n.py
@@ -1,0 +1,56 @@
+from proteus import *
+from proteus.default_n import *
+from pressureincrement_p import *
+
+mesh = domain.MeshOptions
+triangleOptions = triangleOptions
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+
+femSpaces = {0:pbasis}
+
+stepController=FixedStep
+
+#numericalFluxType = PresInc.NumericalFlux
+numericalFluxType = NumericalFlux.ConstantAdvection_exterior
+matrix = LinearAlgebraTools.SparseMatrix
+
+#if openTop:
+#    linearSmoother    = None
+#    multilevelLinearSolver = LinearSolvers.LU
+#    levelLinearSolver      = LinearSolvers.LU
+#else:
+#    linearSmoother         = LinearSolvers.NavierStokesPressureCorrection # pure neumann laplacian solver
+#    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+#    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+linear_solver_options_prefix = 'phi_'
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+else:
+    multilevelLinearSolver = KSP_petsc4py
+    levelLinearSolver      = KSP_petsc4py
+    parallelPartitioningType    = parallelPartitioningType
+    nLayersOfOverlapForParallel = nLayersOfOverlapForParallel
+    nonlinearSmoother = None
+    linearSmoother    = None
+
+
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+#linear solve rtolerance
+
+linTolFac = 0.0
+l_atol_res = 0.01*phi_nl_atol_res
+tolFac = 0.0
+nl_atol_res = phi_nl_atol_res
+nonlinearSolverConvergenceTest = 'r'
+levelNonlinearSolverConvergenceTest = 'r'
+linearSolverConvergenceTest             = 'r-true'
+maxLineSearches=0
+periodicDirichletConditions=None
+
+conservativeFlux = {0:'point-eval'} #'point-eval','pwl-bdm-opt'
+#conservativeFlux=None

--- a/2d/sediment/group_sediment/pressureincrement_p.py
+++ b/2d/sediment/group_sediment/pressureincrement_p.py
@@ -1,0 +1,63 @@
+from math import *
+from proteus import *
+from proteus.default_p import *
+from tank import *
+import tank_so
+from proteus.mprans import PresInc
+from proteus import Context
+
+ct = Context.get()
+
+if ct.sedimentDynamics:
+    VOS_model=0
+    VOF_model=1
+    V_model=6
+    SED_model=5
+    PINC_model=7
+else:
+    VOS_model=None
+    VOF_model=0
+    V_model=4
+    PINC_model=5
+    SED_model=None
+
+
+#domain = ctx.domain
+#nd = ctx.nd
+name = "pressureincrement"
+
+LevelModelType = PresInc.LevelModel
+#from ProjectionScheme import PressureIncrement
+#coefficients=PressureIncrement(rho_f_min = rho_1,
+#                               rho_s_min = rho_s,
+#                               nd = nd,
+#                               modelIndex=PINC_model,
+#                               fluidModelIndex=V_model)
+from proteus.mprans import PresInc
+coefficients=PresInc.Coefficients(rho_f_min = (1.0-1.0e-8)*rho_1,
+                                  rho_s_min = (1.0-1.0e-8)*rho_s,
+                                  nd = nd,
+                                  modelIndex= PINC_model,
+                                  fluidModelIndex= V_model,
+                                  sedModelIndex= SED_model,
+                                  VOF_model= VOF_model,
+                                  VOS_model= VOS_model,
+                                  fixNullSpace=fixNullSpace_PresInc, 
+                                  INTEGRATE_BY_PARTS_DIV_U=ct.INTEGRATE_BY_PARTS_DIV_U_PresInc)
+
+
+#pressure increment should be zero on any pressure dirichlet boundaries
+
+#the advectiveFlux should be zero on any no-flow  boundaries
+
+class getIBC_phi:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+initialConditions = {0:getIBC_phi()}
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].pInc_dirichlet.init_cython()}
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].pInc_advective.init_cython()}
+diffusiveFluxBoundaryConditions = {0:{0: lambda x, flag: domain.bc[flag].pInc_diffusive.init_cython()}}

--- a/2d/sediment/group_sediment/redist_n.py
+++ b/2d/sediment/group_sediment/redist_n.py
@@ -1,0 +1,95 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools,
+                     NumericalFlux)
+from proteus.mprans import RDLS3P
+import redist_p as physics
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+# time stepping
+runCFL = ct.runCFL
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0: ct.basis}
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+massLumping       = False
+numericalFluxType = NumericalFlux.DoNothing
+conservativeFlux  = None
+subgridError      = RDLS3P.SubgridError(physics.coefficients,nd)
+shockCapturing    = RDLS3P.ShockCapturing(physics.coefficients,nd,shockCapturingFactor=ct.rd_shockCapturingFactor,lag=ct.rd_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver  = NonlinearSolvers.Newton
+levelNonlinearSolver       = NonlinearSolvers.Newton
+
+nonlinearSmoother = NonlinearSolvers.NLGaussSeidel
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+if ct.redist_Newton:
+    timeIntegration = NoIntegration
+    stepController = ct.Newton_controller
+    maxNonlinearIts = 50
+    maxLineSearches = 0
+    nonlinearSolverConvergenceTest = 'rits'
+    levelNonlinearSolverConvergenceTest = 'rits'
+    linearSolverConvergenceTest = 'r-true'
+    useEisenstatWalker = False
+else:
+    timeIntegration = BackwardEuler_cfl
+    stepController = RDLS3P.PsiTC
+    runCFL=2.0
+    psitc['nStepsForce']=3
+    psitc['nStepsMax']=50
+    psitc['reduceRatio']=10.0
+    psitc['startRatio']=1.0
+    rtol_res[0] = 0.0
+    atol_res[0] = rd_nl_atol_res
+    useEisenstatWalker = False#True
+    maxNonlinearIts = 1
+    maxLineSearches = 0
+    nonlinearSolverConvergenceTest = 'rits'
+    levelNonlinearSolverConvergenceTest = 'rits'
+    linearSolverConvergenceTest = 'r-true'
+
+linear_solver_options_prefix = 'rdls_'
+
+tolFac = 0.0
+nl_atol_res = ct.rd_nl_atol_res
+linTolFac = 0.01
+l_atol_res = 0.01*ct.rd_nl_atol_res
+useEisenstatWalker = False#True

--- a/2d/sediment/group_sediment/redist_p.py
+++ b/2d/sediment/group_sediment/redist_p.py
@@ -1,0 +1,52 @@
+from proteus import StepControl
+from proteus import *
+from proteus.default_p import *
+from math import *
+from proteus.mprans import RDLS3P
+from proteus import Context
+
+"""
+The redistancing equation in the sloshbox test problem.
+"""
+
+ct = Context.get()
+domain = ct.domain
+nd = domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+
+LevelModelType = RDLS3P.LevelModel
+
+if ct.sedimentDynamics:
+    LS_model=2
+    RD_model=3
+else:
+    LS_model=1
+    RD_model=2
+
+
+coefficients = RDLS3P.Coefficients(applyRedistancing=ct.applyRedistancing,
+                                   epsFact=ct.epsFact_redistance,
+                                   nModelId=LS_model,
+                                   rdModelId=RD_model,
+                                   useMetrics=ct.useMetrics,
+                                   backgroundDiffusionFactor=ct.backgroundDiffusionFactor)
+
+def getDBC_rd(x,flag):
+    pass
+
+dirichletConditions     = {0:getDBC_rd}
+weakDirichletConditions = {0:RDLS3P.setZeroLSweakDirichletBCsSimple}
+
+advectiveFluxBoundaryConditions =  {}
+diffusiveFluxBoundaryConditions = {0:{}}
+
+class PHI_IC:
+    def uOfXT(self, x, t):
+        return x[nd-1] - ct.waterLevel
+
+initialConditions  = {0: PHI_IC()}

--- a/2d/sediment/group_sediment/tank.py
+++ b/2d/sediment/group_sediment/tank.py
@@ -1,0 +1,486 @@
+from proteus import StepControl
+from math import *
+import proteus.MeshTools
+from proteus import Domain, Context
+from proteus.default_n import *
+from proteus.Profiling import logEvent
+from proteus.mprans import SpatialTools as st
+from proteus import Gauges as ga
+from proteus import WaveTools as wt
+from proteus.mprans.SedClosure import  HsuSedStress
+
+
+opts=Context.Options([
+    # predefined test cases
+    ("waterLine_x", 10.00, "Width of free surface from left to right"),
+    ("waterLine_z", 0.3, "Heigth of free surface above bottom"),
+    ("Lx", 2.00, "Length of the numerical domain"),
+    ("Ly", 0.5, "Heigth of the numerical domain"),
+	# fluid paramters
+    ("rho_0", 998.2, "water density"),
+    ("rho_1", 998.2, "air density"),
+    ("nu_0", 1.004e-6, "water kin viscosity"),
+    ("nu_1", 1.004e-6, "air kin viscosity"),
+    ('g',np.array([0.0, -9.8, 0.0]),'Gravitational acceleration'),    
+    # sediment parameters
+    ('cSed', 0.05,'Sediment concentration'),
+    ('rho_s',2600 ,'sediment material density'),
+    ('alphaSed', 150.,'laminar drag coefficient'),
+    ('betaSed', 0.0,'turbulent drag coefficient'),
+    ('grain',0.0025, 'Grain size'),
+    ('packFraction',0.2,'threshold for loose / packed sediment'),
+    ('packMargin',0.01,'transition margin for loose / packed sediment'),
+    ('maxFraction',0.635,'fraction at max  sediment packing'),
+    ('frFraction',0.57,'fraction where contact stresses kick in'),
+    ('sigmaC',1.1,'Schmidt coefficient for turbulent diffusion'),
+    ('C3e',1.2,'Dissipation coefficient '),
+    ('C4e',1.0,'Dissipation coefficient'),
+    ('eR', 0.8, 'Collision stress coefficient (module not functional)'),
+    ('fContact', 0.05,'Contact stress coefficient'),
+    ('mContact', 3.0,'Contact stress coefficient'),
+    ('nContact', 5.0,'Contact stress coefficient'),
+    ('angFriction', pi/6., 'Angle of friction'),
+    ('vos_limiter', 0.05, 'Weak limiter for vos'),
+    ('mu_fr_limiter', 100.00,'Hard limiter for contact stress friction coeff'),
+    # numerical options
+    ("refinement", 75.,"L[0]/refinement"),
+    ("sedimentDynamics", True, "Enable sediment dynamics module"),
+    ("openTop", not True, "Enable open atmosphere for air phase on the top"),
+    ("cfl", 0.90 ,"Target cfl"),
+    ("duration", 6.0 ,"Duration of the simulation"),
+    ("PSTAB", 1.0, "Affects subgrid error"),
+    ("res", 1.0e-10, "Residual tolerance"),
+    ("epsFact_density", 3.0, "Control width of water/air transition zone"),
+    ("epsFact_consrv_diffusion", 1.0, "Affects smoothing diffusion in mass conservation"),
+    ("useRANS", 0, "Switch ON turbulence models: 0-None, 1-K-Epsilon, 2-K-Omega1998, 3-K-Omega1988"), # ns_closure: 1-classic smagorinsky, 2-dynamic smagorinsky, 3-k-epsilon, 4-k-omega
+    ("sigma_k", 1.0, "sigma_k coefficient for the turbulence model"),
+    ("sigma_e", 1.0, "sigma_e coefficient for the turbulence model"),
+    ("Cmu", 0.09, "Cmu coefficient for the turbulence model"),
+    ])
+
+
+# ----- Sediment stress ----- #
+
+sedClosure = HsuSedStress(aDarcy =  opts.alphaSed,
+                          betaForch =  opts.betaSed,
+                          grain =  opts.grain,
+                          packFraction =  opts.packFraction,
+                          packMargin =  opts.packMargin,
+                          maxFraction =  opts.maxFraction,
+                          frFraction =  opts.frFraction,
+                          sigmaC =  opts.sigmaC,
+                          C3e =  opts.C3e,
+                          C4e =  opts.C4e,
+                          eR =  opts.eR,
+                          fContact =  opts.fContact,
+                          mContact =  opts.mContact,
+                          nContact =  opts.nContact,
+                          angFriction =  opts.angFriction,
+                          vos_limiter = opts.vos_limiter,
+                          mu_fr_limiter = opts.mu_fr_limiter,
+                          )
+
+# ----- DOMAIN ----- #
+
+domain = Domain.PlanarStraightLineGraphDomain()
+
+
+# ----- Phisical constants ----- #
+  
+# Water
+rho_0 = opts.rho_0
+nu_0 = opts.nu_0
+
+# Air
+rho_1 = opts.rho_1 # 1.205 #
+nu_1 = opts.nu_1 # 1.500e-5 # 
+
+# Sediment
+rho_s = opts.rho_s
+nu_s = 1000000
+dragAlpha = 0.0
+
+# Surface tension
+sigma_01 = 0.0
+
+# Gravity
+g = opts.g
+gamma_0 = abs(g[1])*rho_0
+
+# Initial condition
+waterLine_x = opts.waterLine_x
+waterLine_z = opts.waterLine_z
+waterLevel = waterLine_z
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Domain and mesh
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+L = (opts.Lx, opts.Ly)
+he = L[0]/opts.refinement
+dim = dimx, dimy = L
+coords = [ dimx/2., dimy/2. ]
+
+boundaryOrientations = {'y-': np.array([0., -1.,0.]),
+                        'x+': np.array([+1, 0.,0.]),
+                        'y+': np.array([0., +1.,0.]),
+                        'x-': np.array([-1., 0.,0.]),
+                        'sponge': None,
+                           }
+boundaryTags = {'y-': 1,
+                    'x+': 2,
+                    'y+': 3,
+                    'x-': 4,
+                    'sponge': 5,
+                       }
+
+tank = st.Rectangle(domain, dim=dim, coords=coords)
+
+
+#############################################################################################################################################################################################################################################################################################################################################################################################
+# ----- BOUNDARY CONDITIONS ----- #
+#############################################################################################################################################################################################################################################################################################################################################################################################
+tank.BC['y-'].setFreeSlip()
+tank.BC['y+'].setFreeSlip()
+tank.BC['x-'].setFreeSlip()
+tank.BC['x+'].setFreeSlip()
+
+# ----- If open boundary at the top
+if opts.openTop:
+    tank.BC['y+'].reset()
+    tank.BC['y+'].setAtmosphere()
+    tank.BC['y+'].us_dirichlet.setConstantBC(0.0)
+    tank.BC['y+'].vs_dirichlet.setConstantBC(0.0)
+    tank.BC['y+'].vos_advective.setConstantBC(0.0)
+    tank.BC['y+'].pInc_dirichlet.setConstantBC(0.0)
+    tank.BC['y+'].pInit_dirichlet.setConstantBC(0.0)
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Turbulence
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+if opts.useRANS:
+    kInflow = 1e-6
+    dissipationInflow = 1e-6
+    tank.BC['x-'].setTurbulentZeroGradient()
+    tank.BC['x+'].setTurbulentZeroGradient()
+    tank.BC['y-'].setTurbulentZeroGradient()
+    tank.BC['y+'].setTurbulentZeroGradient()
+
+######################################################################################################################################################################################################################
+# Numerical Options and other parameters #
+######################################################################################################################################################################################################################
+ 
+domain.MeshOptions.he = he
+
+from math import *
+from proteus import MeshTools, AuxiliaryVariables
+import numpy
+import proteus.MeshTools
+from proteus import Domain
+from proteus.Profiling import logEvent
+from proteus.default_n import *
+from proteus.ctransportCoefficients import smoothedHeaviside
+from proteus.ctransportCoefficients import smoothedHeaviside_integral
+
+st.assembleDomain(domain)
+
+
+#----------------------------------------------------
+# Time stepping and velocity
+#----------------------------------------------------
+
+T=opts.duration
+weak_bc_penalty_constant = 10.0/nu_0 #100
+dt_fixed = 0.001 
+dt_init = min(0.1*dt_fixed,0.001)
+nDTout= int(round(T/dt_fixed))
+runCFL = opts.cfl
+
+sedimentDynamics=opts.sedimentDynamics
+openTop=opts.openTop
+
+#----------------------------------------------------
+#  Discretization -- input options
+#----------------------------------------------------
+
+genMesh = True
+movingDomain = False
+applyRedistancing = True
+useOldPETSc = False
+useSuperlu = False #True
+timeDiscretization = 'be'#'vbdf'#'vbdf'  # 'vbdf', 'be', 'flcbdf'
+spaceOrder = 1
+pspaceOrder = 1
+useHex = False
+useRBLES = 0.0
+useMetrics = 1.0
+applyCorrection = True
+useVF = 1.0
+useOnlyVF = False
+useRANS = opts.useRANS  # 0 -- None
+                        # 1 -- K-Epsilon
+                        # 2 -- K-Omega
+
+
+KILL_PRESSURE_TERM = False
+fixNullSpace_PresInc = True
+INTEGRATE_BY_PARTS_DIV_U_PresInc = True
+CORRECT_VELOCITY = True
+STABILIZATION_TYPE = 0 #0: SUPG, 1: EV via weak residual, 2: EV via strong residual
+
+# Input checks
+if spaceOrder not in [1, 2]:
+    print "INVALID: spaceOrder" + spaceOrder
+    sys.exit()
+
+if useRBLES not in [0.0, 1.0]:
+    print "INVALID: useRBLES" + useRBLES
+    sys.exit()
+
+if useMetrics not in [0.0, 1.0]:
+    print "INVALID: useMetrics"
+    sys.exit()
+
+#  Discretization
+nd = tank.nd
+
+if spaceOrder == 1:
+    hFactor = 1.0
+    if useHex:
+        basis = C0_AffineLinearOnCubeWithNodalBasis
+        elementQuadrature = CubeGaussQuadrature(nd, 2)
+        elementBoundaryQuadrature = CubeGaussQuadrature(nd - 1, 2)
+    else:
+        basis = C0_AffineLinearOnSimplexWithNodalBasis
+        elementQuadrature = SimplexGaussQuadrature(nd, 3)
+        elementBoundaryQuadrature = SimplexGaussQuadrature(nd - 1, 3)
+elif spaceOrder == 2:
+    hFactor = 0.5
+    if useHex:
+        basis = C0_AffineLagrangeOnCubeWithNodalBasis
+        elementQuadrature = CubeGaussQuadrature(nd, 4)
+        elementBoundaryQuadrature = CubeGaussQuadrature(nd - 1, 4)
+    else:
+        basis = C0_AffineQuadraticOnSimplexWithNodalBasis
+        elementQuadrature = SimplexGaussQuadrature(nd, 4)
+        elementBoundaryQuadrature = SimplexGaussQuadrature(nd - 1, 4)
+
+if pspaceOrder == 1:
+    if useHex:
+        pbasis = C0_AffineLinearOnCubeWithNodalBasis
+    else:
+        pbasis = C0_AffineLinearOnSimplexWithNodalBasis
+elif pspaceOrder == 2:
+    if useHex:
+        pbasis = C0_AffineLagrangeOnCubeWithNodalBasis
+    else:
+        pbasis = C0_AffineQuadraticOnSimplexWithNodalBasis
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Numerical parameters
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+ns_forceStrongDirichlet = False
+ns_sed_forceStrongDirichlet = False
+backgroundDiffusionFactor=0.01
+
+if useMetrics:
+    ns_shockCapturingFactor = 0.5
+    ns_lag_shockCapturing = True
+    ns_lag_subgridError = True
+    ns_sed_shockCapturingFactor = 0.5
+    ns_sed_lag_shockCapturing = True
+    ns_sed_lag_subgridError = True
+    ls_shockCapturingFactor = 0.5
+    ls_lag_shockCapturing = True
+    ls_sc_uref = 1.0
+    ls_sc_beta = 1.0
+    vof_shockCapturingFactor = 0.5
+    vof_lag_shockCapturing = True
+    vof_sc_uref = 1.0
+    vof_sc_beta = 1.0
+    vos_shockCapturingFactor = 0.9 # <------------------------------------- 
+    vos_lag_shockCapturing = True
+    vos_sc_uref = 1.0
+    vos_sc_beta = 1.0
+    rd_shockCapturingFactor = 0.5
+    rd_lag_shockCapturing = False
+    epsFact_vos = 5.0 # <------------------------------------- 
+    epsFact_density = opts.epsFact_density # 1.5
+    epsFact_viscosity = epsFact_curvature = epsFact_vof = epsFact_consrv_heaviside = epsFact_consrv_dirac = epsFact_density
+    epsFact_redistance = 0.33
+    epsFact_consrv_diffusion = opts.epsFact_consrv_diffusion # 0.1
+    redist_Newton = True
+    kappa_shockCapturingFactor = 0.25
+    kappa_lag_shockCapturing = True  #False
+    kappa_sc_uref = 1.0
+    kappa_sc_beta = 1.0
+    dissipation_shockCapturingFactor = 0.25
+    dissipation_lag_shockCapturing = True  #False
+    dissipation_sc_uref = 1.0
+    dissipation_sc_beta = 1.0
+else:
+    ns_shockCapturingFactor = 0.9
+    ns_lag_shockCapturing = True
+    ns_lag_subgridError = True
+    ns_sed_shockCapturingFactor = 0.9
+    ns_sed_lag_shockCapturing = True
+    ns_sed_lag_subgridError = True
+    ls_shockCapturingFactor = 0.9
+    ls_lag_shockCapturing = True
+    ls_sc_uref = 1.0
+    ls_sc_beta = 1.0
+    vof_shockCapturingFactor = 0.9
+    vof_lag_shockCapturing = True
+    vof_sc_uref = 1.0
+    vof_sc_beta = 1.0
+    vos_shockCapturingFactor = 0.9
+    vos_lag_shockCapturing = True
+    vos_sc_uref = 1.0
+    vos_sc_beta = 1.0
+    rd_shockCapturingFactor = 0.9
+    rd_lag_shockCapturing = False
+    epsFact_density = opts.epsFact_density # 1.5
+    epsFact_viscosity = epsFact_curvature = epsFact_vof = epsFact_vos = epsFact_consrv_heaviside = epsFact_consrv_dirac = epsFact_density
+    epsFact_redistance = 0.33
+    epsFact_consrv_diffusion = opts.epsFact_consrv_diffusion # 1.0
+    redist_Newton = False
+    kappa_shockCapturingFactor = 0.9
+    kappa_lag_shockCapturing = True  #False
+    kappa_sc_uref = 1.0
+    kappa_sc_beta = 1.0
+    dissipation_shockCapturingFactor = 0.9
+    dissipation_lag_shockCapturing = True  #False
+    dissipation_sc_uref = 1.0
+    dissipation_sc_beta = 1.0
+
+ns_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+ns_sed_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+vof_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+vos_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+ls_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+rd_nl_atol_res =  max(opts.res, 0.005 * he)
+mcorr_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+kappa_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+dissipation_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+phi_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+pressure_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Turbulence
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+ns_closure = 0  #1-classic smagorinsky, 2-dynamic smagorinsky, 3 -- k-epsilon, 4 -- k-omega
+ns_sed_closure = 0  #1-classic smagorinsky, 2-dynamic smagorinsky, 3 -- k-epsilon, 4 -- k-omega
+if useRANS == 1:
+    ns_closure = 3
+elif useRANS == 2:
+    ns_closure == 4
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Functions for model variables - Initial conditions
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+def signedDistance(x):
+    phi_z = x[1] - waterLine_z
+    return phi_z
+
+def vos_signedDistance(x):
+    phi_z = x[1] - 0.75*waterLine_z
+    return phi_z
+
+class Suspension_class:
+    def __init__(self):
+        pass
+    def uOfXT(self, x, t=0):
+        phi = signedDistance(x) + 0.1
+        phiBottom = x[1] - 0.05
+        phiLeft = x[0] - 0.8
+        phiRight = x[0] - (dimx-0.8)
+        smoothing = (epsFact_consrv_heaviside)*he/2.
+        Heav = smoothedHeaviside(smoothing, phi)     
+        HeavBottom = smoothedHeaviside(smoothing, phiBottom)     
+        HeavLeft = smoothedHeaviside(smoothing, phiLeft)     
+        HeavRight = smoothedHeaviside(smoothing, phiRight)        
+        if phiLeft>=smoothing and phiRight<=-smoothing:
+            if phi <= -smoothing:
+                if phiBottom >= smoothing:
+                    return opts.cSed
+                elif -smoothing < phiBottom < smoothing :
+                    return opts.cSed * (HeavBottom)
+                else:
+                    return 1e-10            
+            elif -smoothing < phi < smoothing:
+                return opts.cSed * (1.-Heav)            
+            else:
+                return 1e-10    
+        elif -smoothing < phiLeft < smoothing:
+            if phi <= 0.0 and phiBottom >= 0.0:
+                return opts.cSed * (HeavLeft)
+            elif 0. < phi < smoothing:
+                return opts.cSed * (1.-Heav)
+            elif 0. > phiBottom > -smoothing:
+                return opts.cSed * (HeavBottom)
+            else:
+                return 1e-10 
+        elif -smoothing < phiRight < smoothing:
+            if phi <= 0.0 and phiBottom >= 0.0:
+                return opts.cSed * (1.-HeavRight)
+            elif 0. < phi < smoothing:
+                return opts.cSed * (1.-Heav)
+            elif 0. > phiBottom > -smoothing:
+                return opts.cSed * (HeavBottom)
+            else:
+                return 1e-10 
+        else:
+            return 1e-10
+
+def vos_function(x, t=0):
+    phi = signedDistance(x) + 0.1
+    phiBottom = x[1] - 0.05
+    phiLeft = x[0] - 0.8
+    phiRight = x[0] - (dimx-0.8)
+    smoothing = (epsFact_consrv_heaviside)*he/2.
+    Heav = smoothedHeaviside(smoothing, phi)     
+    HeavBottom = smoothedHeaviside(smoothing, phiBottom)     
+    HeavLeft = smoothedHeaviside(smoothing, phiLeft)     
+    HeavRight = smoothedHeaviside(smoothing, phiRight)        
+    if phiLeft>=smoothing and phiRight<=-smoothing:
+        if phi <= -smoothing:
+            if phiBottom >= smoothing:
+                return opts.cSed
+            elif -smoothing < phiBottom < smoothing :
+                return opts.cSed * (HeavBottom)
+            else:
+                return 1e-10            
+        elif -smoothing < phi < smoothing:
+            return opts.cSed * (1.-Heav)            
+        else:
+            return 1e-10    
+    elif -smoothing < phiLeft < smoothing:
+        if phi <= 0.0 and phiBottom >= 0.0:
+            return opts.cSed * (HeavLeft)
+        elif 0. < phi < smoothing:
+            return opts.cSed * (1.-Heav)
+        elif 0. > phiBottom > -smoothing:
+            return opts.cSed * (HeavBottom)
+        else:
+            return 1e-10 
+    elif -smoothing < phiRight < smoothing:
+        if phi <= 0.0 and phiBottom >= 0.0:
+            return opts.cSed * (1.-HeavRight)
+        elif 0. < phi < smoothing:
+            return opts.cSed * (1.-Heav)
+        elif 0. > phiBottom > -smoothing:
+            return opts.cSed * (HeavBottom)
+        else:
+            return 1e-10 
+    else:
+        return 1e-10
+
+
+Suspension = Suspension_class()

--- a/2d/sediment/group_sediment/tank_so.py
+++ b/2d/sediment/group_sediment/tank_so.py
@@ -1,0 +1,83 @@
+from proteus import StepControl
+"""
+Split operator module for two-phase flow
+"""
+
+from proteus.default_so import *
+import os
+from proteus import Context
+
+# Create context from main module
+name_so = os.path.basename(__file__)
+if '_so.py' in name_so[-6:]:
+    name = name_so[:-6]
+elif '_so.pyc' in name_so[-7:]:
+    name = name_so[:-7]
+else:
+    raise NameError, 'Split operator module must end with "_so.py"'
+
+try:
+    case = __import__(name)
+    Context.setFromModule(case)
+    ct = Context.get()
+except ImportError:
+    raise ImportError, str(name) + '.py not found'
+
+from proteus import BoundaryConditions
+for BC in ct.domain.bc:
+    BC.getContext()
+
+from proteus.SplitOperator import Sequential_FixedStep_Simple, defaultSystem
+if ct.sedimentDynamics:
+    PINIT_model=9
+    pnList = [("vos_p",               "vos_n"),#0
+              ("vof_p",               "vof_n"),#1
+              ("ls_p",                "ls_n"),#2
+              ("redist_p",            "redist_n"),#3
+              ("ls_consrv_p",         "ls_consrv_n"),#4
+              ("threep_navier_stokes_sed_p", "threep_navier_stokes_sed_n"),#5
+              ("twp_navier_stokes_p", "twp_navier_stokes_n"),#6
+              ("pressureincrement_p", "pressureincrement_n"),#7
+              ("pressure_p", "pressure_n"),#8
+              ("pressureInitial_p", "pressureInitial_n")]#9
+else:
+    PINIT_model=7
+    pnList = [("vof_p",               "vof_n"),#0
+              ("ls_p",                "ls_n"),#1
+              ("redist_p",            "redist_n"),#2
+              ("ls_consrv_p",         "ls_consrv_n"),#3
+              ("twp_navier_stokes_p", "twp_navier_stokes_n"),#4
+              ("pressureincrement_p", "pressureincrement_n"),#5
+              ("pressure_p", "pressure_n"),#6
+              ("pressureInitial_p", "pressureInitial_n")]#7
+
+if ct.useRANS > 0:
+    pnList.append(("kappa_p",
+                   "kappa_n"))
+    pnList.append(("dissipation_p",
+                   "dissipation_n"))
+name = "tank"
+
+#modelSpinUpList = [ct.VOF_model, ct.LS_model, ct.V_model, ct.PINIT_model]
+modelSpinUpList = [PINIT_model]
+
+class Sequential_MinAdaptiveModelStepPS(Sequential_MinAdaptiveModelStep):
+    def __init__(self,modelList,system=defaultSystem,stepExact=True):
+        Sequential_MinAdaptiveModelStep.__init__(self,modelList,system,stepExact)
+        self.modelList = modelList[:len(pnList)-1]
+
+#class Sequential_MinAdaptiveModelStepPS(Sequential_FixedStep):
+#    def __init__(self,modelList,system=defaultSystem,stepExact=True):
+#        Sequential_FixedStep.__init__(self,modelList,system,stepExact)
+#        self.modelList = modelList[:len(pnList)-1]
+
+dt_system_fixed = ct.dt_fixed
+systemStepControllerType = Sequential_MinAdaptiveModelStepPS
+
+needEBQ_GLOBAL = False
+needEBQ = False
+
+tnList = [0.0,ct.dt_init]+[ct.dt_init+i*ct.dt_fixed for i in range(1,ct.nDTout+1)]
+
+info = open("TimeList.txt","w")
+#archiveFlag = ArchiveFlags.EVERY_SEQUENCE_STEP

--- a/2d/sediment/group_sediment/threep_navier_stokes_sed_n.py
+++ b/2d/sediment/group_sediment/threep_navier_stokes_sed_n.py
@@ -1,0 +1,71 @@
+from proteus import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+from threep_navier_stokes_sed_p import *
+from tank import *
+
+if timeDiscretization=='vbdf':
+    timeIntegration = VBDF
+    timeOrder=2
+    stepController  = Min_dt_cfl_controller
+elif timeDiscretization=='flcbdf':
+    timeIntegration = FLCBDF
+    #stepController = FLCBDF_controller_sys
+    stepController  = Min_dt_cfl_controller
+    time_tol = 10.0*ns_sed_nl_atol_res
+    atol_u = {0:time_tol,1:time_tol}
+    rtol_u = {0:time_tol,1:time_tol}
+else:
+    timeIntegration = BackwardEuler_cfl
+    stepController  = Min_dt_cfl_controller
+
+femSpaces = {0:basis,
+	     1:basis}
+
+massLumping       = False
+numericalFluxType = None
+conservativeFlux  = None
+
+numericalFluxType = RANS3PSed.NumericalFlux
+subgridError = RANS3PSed.SubgridError(coefficients,nd,lag=ns_sed_lag_subgridError,hFactor=hFactor)
+shockCapturing = RANS3PSed.ShockCapturing(coefficients,nd,ns_sed_shockCapturingFactor,lag=ns_sed_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+
+linearSmoother    = None
+
+matrix = SparseMatrix
+
+if useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'rans3p_sed_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest             = 'r-true'
+
+tolFac = 0.0
+linTolFac = 0.01
+l_atol_res = 0.01*ns_sed_nl_atol_res
+nl_atol_res = ns_sed_nl_atol_res
+useEisenstatWalker = False
+maxNonlinearIts = 50
+maxLineSearches = 0
+conservativeFlux = {0:'point-eval'}
+#conservativeFlux = {0:'pwl-bdm-opt'}
+#auxiliaryVariables=[pointGauges,lineGauges]

--- a/2d/sediment/group_sediment/threep_navier_stokes_sed_p.py
+++ b/2d/sediment/group_sediment/threep_navier_stokes_sed_p.py
@@ -1,0 +1,118 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import RANS3PSed
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = RANS3PSed.LevelModel
+
+if ct.sedimentDynamics:
+    VOS_model=0
+    VOF_model=1
+    LS_model=2
+    RD_model=3
+    MCORR_model=4
+    SED_model=5
+    V_model=6
+    PINC_model=7
+    PRESSURE_model=8
+    PINIT_model=9
+else:
+    VOS_model=None
+    SED_model=None
+    VOF_model=0
+    LS_model=1
+    RD_model=2
+    MCORR_model=3
+    V_model=4
+    PINC_model=5
+    PRESSURE_model=6
+    PINIT_model=7
+
+if useOnlyVF:
+    LS_model = None
+else:
+    LS_model = 2
+if useRANS >= 1:
+    Closure_0_model = 5; Closure_1_model=6
+    if useOnlyVF:
+        Closure_0_model=2; Closure_1_model=3
+    if movingDomain:
+        Closure_0_model += 1; Closure_1_model += 1
+else:
+    Closure_0_model = None
+    Closure_1_model = None
+
+coefficients = RANS3PSed.Coefficients(epsFact=epsFact_viscosity,
+                                      sigma=0.0,
+                                      rho_0 = rho_0,
+                                      nu_0 = nu_0, 
+                                      rho_1 = rho_1,
+                                      nu_1 = nu_1,
+                                      rho_s = rho_s,
+                                      g=g,
+                                      nd=nd,
+                                      ME_model=SED_model,
+                                      PRESSURE_model=PRESSURE_model,
+                                      FLUID_model=V_model,
+                                      VOS_model=VOS_model,
+                                      VOF_model=VOF_model,
+                                      LS_model=LS_model,
+                                      Closure_0_model=Closure_0_model,
+                                      Closure_1_model=Closure_1_model,
+                                      epsFact_density=epsFact_density,
+                                      stokes=False,
+                                      useVF=True,
+                                      useRBLES=useRBLES,
+                                      useMetrics=useMetrics,
+                                      eb_adjoint_sigma=1.0,
+                                      eb_penalty_constant=weak_bc_penalty_constant,
+                                      forceStrongDirichlet=ns_forceStrongDirichlet,
+                                      turbulenceClosureModel=ns_closure,
+                                      movingDomain=movingDomain,
+                                      dragAlpha=dragAlpha,
+                                      PSTAB=ct.opts.PSTAB,
+                                    aDarcy = sedClosure.aDarcy,
+                                    betaForch = sedClosure.betaForch,
+                                    grain = sedClosure.grain,
+                                    packFraction = sedClosure.packFraction,
+                                    maxFraction = sedClosure.maxFraction,
+                                    frFraction = sedClosure.frFraction,
+                                    sigmaC = sedClosure.sigmaC,
+                                    C3e = sedClosure.C3e,
+                                    C4e = sedClosure.C4e,
+                                    eR = sedClosure.eR,
+                                    fContact = sedClosure.fContact,
+                                    mContact = sedClosure.mContact,
+                                    nContact = sedClosure.nContact,
+                                    angFriction = sedClosure.angFriction,
+                                    vos_function = ct.vos_function,
+                                    staticSediment = False,
+                                    vos_limiter = ct.sedClosure.vos_limiter,
+                                    mu_fr_limiter = ct.sedClosure.mu_fr_limiter,
+                                    )
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].us_dirichlet.init_cython(),
+                       1: lambda x, flag: domain.bc[flag].vs_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].us_advective.init_cython(),
+                                   1: lambda x, flag: domain.bc[flag].vs_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {0: lambda x, flag: domain.bc[flag].us_diffusive.init_cython()},
+                                   1: {1: lambda x, flag: domain.bc[flag].vs_diffusive.init_cython()}}
+
+if nd == 3:
+    dirichletConditions[2] = lambda x, flag: domain.bc[flag].ws_dirichlet.init_cython()
+    advectiveFluxBoundaryConditions[2] = lambda x, flag: domain.bc[flag].ws_advective.init_cython()
+    diffusiveFluxBoundaryConditions[2] = {2: lambda x, flag: domain.bc[flag].ws_diffusive.init_cython()}
+
+class AtRest:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+initialConditions = {0:AtRest(),
+                     1:AtRest()}

--- a/2d/sediment/group_sediment/twp_navier_stokes_n.py
+++ b/2d/sediment/group_sediment/twp_navier_stokes_n.py
@@ -1,0 +1,73 @@
+from proteus import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+from twp_navier_stokes_p import *
+from tank import *
+
+if timeDiscretization=='vbdf':
+    timeIntegration = VBDF
+    timeOrder=2
+    stepController  = Min_dt_cfl_controller
+elif timeDiscretization=='flcbdf':
+    timeIntegration = FLCBDF
+    #stepController = FLCBDF_controller_sys
+    stepController  = Min_dt_cfl_controller
+    time_tol = 10.0*ns_nl_atol_res
+    atol_u = {0:time_tol,1:time_tol}
+    rtol_u = {0:time_tol,1:time_tol}
+else:
+    timeIntegration = BackwardEuler_cfl
+    stepController  = Min_dt_cfl_controller
+
+femSpaces = {0:basis,
+	     1:basis}
+#femSpaces = {0:C0_AffineQuadraticOnSimplexWithNodalBasis,
+#             1:C0_AffineQuadraticOnSimplexWithNodalBasis}
+
+massLumping       = False
+numericalFluxType = None
+conservativeFlux  = None
+
+numericalFluxType = RANS3PF.NumericalFlux
+subgridError = RANS3PF.SubgridError(coefficients,nd,lag=ns_lag_subgridError,hFactor=hFactor)
+shockCapturing = RANS3PF.ShockCapturing(coefficients,nd,ns_shockCapturingFactor,lag=ns_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+
+linearSmoother    = None #SimpleNavierStokes2D
+
+matrix = SparseMatrix
+
+if useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'rans2p_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest             = 'r-true'
+
+tolFac = 0.0
+linTolFac = 0.01
+l_atol_res = 0.01*ns_nl_atol_res
+nl_atol_res = ns_nl_atol_res
+useEisenstatWalker = False
+maxNonlinearIts = 50
+maxLineSearches = 0
+conservativeFlux = {0:'point-eval'}
+#conservativeFlux = {0:'pwl-bdm-opt'}
+#auxiliaryVariables=[pointGauges,lineGauges]

--- a/2d/sediment/group_sediment/twp_navier_stokes_p.py
+++ b/2d/sediment/group_sediment/twp_navier_stokes_p.py
@@ -1,0 +1,115 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import RANS3PF
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = RANS3PF.LevelModel
+
+if ct.sedimentDynamics:
+    VOS_model=0
+    VOF_model=1
+    LS_model=2
+    RD_model=3
+    MCORR_model=4
+    SED_model=5
+    V_model=6
+    PINC_model=7
+    PRESSURE_model=8
+    PINIT_model=9
+else:
+    VOS_model=None
+    SED_model=None
+    VOF_model=0
+    LS_model=1
+    RD_model=2
+    MCORR_model=3
+    V_model=4
+    PINC_model=5
+    PRESSURE_model=6
+    PINIT_model=7
+if useOnlyVF:
+    LS_model = None
+else:
+    LS_model = 2
+if useRANS >= 1:
+    Closure_0_model = 5; Closure_1_model=6
+    if useOnlyVF:
+        Closure_0_model=2; Closure_1_model=3
+    if movingDomain:
+        Closure_0_model += 1; Closure_1_model += 1
+else:
+    Closure_0_model = None
+    Closure_1_model = None
+
+coefficients = RANS3PF.Coefficients(epsFact=epsFact_viscosity,
+                                    sigma=0.0,
+                                    rho_0 = rho_0,
+                                    nu_0 = nu_0,
+                                    rho_1 = rho_1,
+                                    nu_1 = nu_1,
+                                    g=g,
+                                    nd=nd,
+                                    ME_model=V_model,
+                                    PRESSURE_model=PRESSURE_model,
+                                    SED_model=SED_model,
+                                    VOF_model=VOF_model,
+                                    VOS_model=VOS_model,
+                                    LS_model=LS_model,
+                                    Closure_0_model=Closure_0_model,
+                                    Closure_1_model=Closure_1_model,
+                                    epsFact_density=epsFact_density,
+                                    stokes=False,
+                                    useVF=useVF,
+                                    useRBLES=useRBLES,
+                                    useMetrics=useMetrics,
+                                    eb_adjoint_sigma=1.0,
+                                    eb_penalty_constant=weak_bc_penalty_constant,
+                                    forceStrongDirichlet=ns_forceStrongDirichlet,
+                                    turbulenceClosureModel=ns_closure,
+                                    movingDomain=movingDomain,
+                                    dragAlpha=dragAlpha,
+                                    PSTAB=ct.opts.PSTAB,
+                                    aDarcy = sedClosure.aDarcy,
+                                    betaForch = sedClosure.betaForch,
+                                    grain = sedClosure.grain,
+                                    packFraction = sedClosure.packFraction,
+                                    maxFraction = sedClosure.maxFraction,
+                                    frFraction = sedClosure.frFraction,
+                                    sigmaC = sedClosure.sigmaC,
+                                    C3e = sedClosure.C3e,
+                                    C4e = sedClosure.C4e,
+                                    eR = sedClosure.eR,
+                                    fContact = sedClosure.fContact,
+                                    mContact = sedClosure.mContact,
+                                    nContact = sedClosure.nContact,
+                                    angFriction = sedClosure.angFriction,
+                                    vos_function = ct.vos_function,
+                                    vos_limiter = ct.sedClosure.vos_limiter,
+                                    mu_fr_limiter = ct.sedClosure.mu_fr_limiter,
+                                    )
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].u_dirichlet.init_cython(),
+                       1: lambda x, flag: domain.bc[flag].v_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].u_advective.init_cython(),
+                                   1: lambda x, flag: domain.bc[flag].v_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {0: lambda x, flag: domain.bc[flag].u_diffusive.init_cython()},
+                                   1: {1: lambda x, flag: domain.bc[flag].v_diffusive.init_cython()}}
+
+if nd == 3:
+    dirichletConditions[2] = lambda x, flag: domain.bc[flag].w_dirichlet.init_cython()
+    advectiveFluxBoundaryConditions[2] = lambda x, flag: domain.bc[flag].w_advective.init_cython()
+    diffusiveFluxBoundaryConditions[2] = {2: lambda x, flag: domain.bc[flag].w_diffusive.init_cython()}
+
+class AtRest:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+initialConditions = {0:AtRest(),
+                     1:AtRest()}

--- a/2d/sediment/group_sediment/vof_n.py
+++ b/2d/sediment/group_sediment/vof_n.py
@@ -1,0 +1,77 @@
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import vof_p as physics
+from proteus.mprans import VOF3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+# time stepping
+runCFL = ct.runCFL
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_controller
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = VOF3P.NumericalFlux
+conservativeFlux  = None
+subgridError      = VOF3P.SubgridError(coefficients=physics.coefficients,nd=nd)
+shockCapturing    = VOF3P.ShockCapturing(physics.coefficients,nd,shockCapturingFactor=ct.vof_shockCapturingFactor,lag=ct.vof_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'vof_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'r-true'
+
+tolFac      = 0.0
+nl_atol_res = ct.vof_nl_atol_res
+
+linTolFac   = 0.0
+l_atol_res = 0.1*ct.vof_nl_atol_res
+
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+
+auxiliaryVariables = ct.domain.auxiliaryVariables['vof']

--- a/2d/sediment/group_sediment/vof_p.py
+++ b/2d/sediment/group_sediment/vof_p.py
@@ -1,0 +1,52 @@
+from proteus.default_p import *
+from proteus.ctransportCoefficients import smoothedHeaviside
+from proteus.mprans import VOF3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+LevelModelType = VOF3P.LevelModel
+
+if ct.sedimentDynamics:
+    LS_model=2
+    V_model=6
+    RD_model=3
+    VOF_model=1
+    VOS_model=0
+else:
+    VOS_model=None
+    VOF_model=0
+    LS_model=1
+    RD_model=2
+    V_model=4
+
+coefficients = VOF3P.Coefficients(LS_model=LS_model,
+                                  V_model=V_model,
+                                  RD_model=RD_model,
+                                  ME_model=VOF_model,
+                                  VOS_model=VOS_model,
+                                  checkMass=True,
+                                  useMetrics=ct.useMetrics,
+                                  epsFact=ct.epsFact_vof,
+                                  sc_uref=ct.vof_sc_uref,
+                                  sc_beta=ct.vof_sc_beta,
+                                  movingDomain=ct.movingDomain)
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].vof_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].vof_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {}}
+
+class VF_IC:
+    def uOfXT(self, x, t):
+        return smoothedHeaviside(ct.epsFact_consrv_heaviside*mesh.he,x[nd-1]-ct.waterLevel)
+
+initialConditions = {0: VF_IC()}

--- a/2d/sediment/group_sediment/vos_n.py
+++ b/2d/sediment/group_sediment/vos_n.py
@@ -1,0 +1,80 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import vof_p as physics
+from proteus import Context
+from proteus.mprans import VOS3P
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+# time stepping
+runCFL = ct.runCFL
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_controller
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = VOS3P.NumericalFlux
+conservativeFlux  = None
+subgridError      = VOS3P.SubgridError(coefficients=physics.coefficients,nd=nd)
+shockCapturing    = VOS3P.ShockCapturing(physics.coefficients,nd,shockCapturingFactor=ct.vos_shockCapturingFactor,lag=ct.vos_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'vos_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'r-true'
+
+tolFac      = 0.0
+nl_atol_res = ct.vos_nl_atol_res
+
+linTolFac   = 0.0
+l_atol_res = 0.1*ct.vos_nl_atol_res
+
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+
+#auxiliaryVariables = ct.domain.auxiliaryVariables['vos']

--- a/2d/sediment/group_sediment/vos_p.py
+++ b/2d/sediment/group_sediment/vos_p.py
@@ -1,0 +1,44 @@
+from proteus import StepControl
+from proteus.default_p import *
+from proteus.ctransportCoefficients import smoothedHeaviside
+from proteus.mprans import VOS3P
+from proteus import Context
+from proteus import *
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+LevelModelType = VOS3P.LevelModel
+
+
+if ct.sedimentDynamics:
+    V_model=6
+    SED_model=5
+else:
+    V_model=4
+    SED_model=None
+
+coefficients = VOS3P.Coefficients(LS_model=None,
+                                  V_model=V_model,
+                                  SED_model=SED_model,
+                                  RD_model=None,
+                                  ME_model=0,
+                                  checkMass=False,
+                                  useMetrics=ct.useMetrics,
+                                  epsFact=ct.epsFact_vos,
+                                  sc_uref=ct.vos_sc_uref,
+                                  sc_beta=ct.vos_sc_beta,
+                                  movingDomain=ct.movingDomain,
+                                  vos_function=ct.vos_function,
+                                  )
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].vos_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].vos_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {}}
+
+
+initialConditions  = {0:ct.Suspension}

--- a/2d/sediment/pipe_scour/TimeSeriesPlot.py
+++ b/2d/sediment/pipe_scour/TimeSeriesPlot.py
@@ -1,0 +1,54 @@
+from proteus import StepControl
+#from scipy import *
+from pylab import *
+from numpy import *
+import collections as cll
+
+filename='pointGauge_pressure.txt'
+headerline = 0
+
+
+# Read header info 
+
+fid = open(filename,'r')
+prdata=loadtxt(fid,skiprows=headerline)
+fid.seek(0)
+D = fid.readlines()
+header = D[:headerline]
+n=len(D)
+
+a = array(zeros((int(n),5)))
+step = zeros(int(n),float)
+for i in range (int(n)):
+ a[i,:]=D[i].split()
+ step[i]=i
+
+a = array(a,dtype=float32)
+
+y = zeros(int(n),float)
+
+y[:] = a[:,2]
+
+
+
+
+
+
+#j=str(2)
+
+fig1 = figure(1)
+fig1.add_subplot(1,1,1)
+plot(step[:],y[:],"k",lw=2)
+
+##xlim(80,90)
+##ylim(-0.05,0.05)
+
+grid()
+#title('Surface elevation at $x=$' + str(probex[int(j)])+'m')
+title('Point gauge pressure evolution')
+xlabel('Step')
+ylabel('Pressure')
+
+show()
+savefig('plottrial.pdf')
+savefig('plottrial.png',dpi=100)

--- a/2d/sediment/pipe_scour/dissipation_n.py
+++ b/2d/sediment/pipe_scour/dissipation_n.py
@@ -1,0 +1,59 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import dissipation_p as physics
+from proteus import Context
+from proteus.mprans import Dissipation
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+triangleOptions = mesh.triangleOptions
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_cfl_controller
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = Dissipation.NumericalFlux
+conservativeFlux  = None
+subgridError      = Dissipation.SubgridError(coefficients=physics.coefficients,nd=ct.nd)
+shockCapturing    = Dissipation.ShockCapturing(physics.coefficients,ct.nd,shockCapturingFactor=ct.dissipation_shockCapturingFactor,
+                                         lag=ct.dissipation_lag_shockCapturing)
+
+fullNewtonFlag  = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+#printNonlinearSolverInfo = True
+matrix = SparseMatrix
+if not ct.useOldPETSc and not ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+else:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'dissipation_'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'rits'
+
+tolFac = 0.0
+linTolFac =0.0
+l_atol_res = 0.001*ct.dissipation_nl_atol_res
+nl_atol_res = ct.dissipation_nl_atol_res
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+

--- a/2d/sediment/pipe_scour/dissipation_p.py
+++ b/2d/sediment/pipe_scour/dissipation_p.py
@@ -1,0 +1,58 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import Dissipation
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = Dissipation.LevelModel
+if useOnlyVF:
+    RD_model = None
+    LS_model = None
+    dissipation_model = 3
+    ME_model = 2
+else:
+    RD_model = 3
+    LS_model = 2
+    ME_model = 6
+    kappa_model = 5
+
+dissipation_model_flag = 1
+if ct.useRANS >= 2:
+    dissipation_model_flag=2
+coefficients = Dissipation.Coefficients(V_model=0+int(ct.movingDomain),
+                                        ME_model=ME_model+int(ct.movingDomain),
+                                        LS_model=LS_model+int(ct.movingDomain),
+                                        RD_model=RD_model+int(ct.movingDomain),
+                                        kappa_model=kappa_model+int(ct.movingDomain),
+                                        dissipation_model_flag=dissipation_model_flag+int(ct.movingDomain),#1 -- K-epsilon, 2 -- K-omega
+                                  useMetrics=useMetrics,
+                                  rho_0=rho_0,nu_0=nu_0,
+                                  rho_1=rho_1,nu_1=nu_1,
+                                  g=g,
+                                  c_mu=ct.opts.Cmu,sigma_e=ct.opts.sigma_e,
+                                  sc_uref=dissipation_sc_uref,
+                                  sc_beta=dissipation_sc_beta)
+
+kInflow=ct.kInflow
+
+dissipationInflow=ct.dissipationInflow
+
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].dissipation_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].dissipation_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {},
+                                   1: {1: lambda x, flag: domain.bc[flag].dissipation_diffusive.init_cython()},
+                                  }
+
+ 
+class ConstantIC:
+    def __init__(self,cval=0.0):
+        self.cval=cval
+    def uOfXT(self,x,t):
+        return self.cval
+
+initialConditions  = {0:ConstantIC(cval=dissipationInflow)}

--- a/2d/sediment/pipe_scour/eddy_viscosity_view_batch.py
+++ b/2d/sediment/pipe_scour/eddy_viscosity_view_batch.py
@@ -1,0 +1,7 @@
+from proteus import StepControl
+#0 is Navier-Stokes flow model
+simFlagsList[0]['storeQuantities']= ['simulationData',"q:'eddy_viscosity'"]
+simFlagsList[0]['storeTimes']     = ['All']
+#
+start
+quit

--- a/2d/sediment/pipe_scour/kappa_n.py
+++ b/2d/sediment/pipe_scour/kappa_n.py
@@ -1,0 +1,61 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import kappa_p as physics
+from proteus import Context
+from proteus.mprans import Kappa
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+triangleOptions = mesh.triangleOptions
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_cfl_controller
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = Kappa.NumericalFlux
+conservativeFlux  = None
+subgridError      = Kappa.SubgridError(coefficients=physics.coefficients,nd=ct.nd)
+shockCapturing    = Kappa.ShockCapturing(physics.coefficients,ct.nd,shockCapturingFactor=ct.kappa_shockCapturingFactor,
+                                         lag=ct.kappa_lag_shockCapturing)
+
+fullNewtonFlag  = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+#printNonlinearSolverInfo = True
+matrix = SparseMatrix
+if not ct.useOldPETSc and not ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+else:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'kappa_'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'rits'
+
+tolFac = 0.0
+linTolFac =0.0
+l_atol_res = 0.001*ct.kappa_nl_atol_res
+nl_atol_res = ct.kappa_nl_atol_res
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+
+auxiliaryVariables = ct.domain.auxiliaryVariables['kappa']
+

--- a/2d/sediment/pipe_scour/kappa_p.py
+++ b/2d/sediment/pipe_scour/kappa_p.py
@@ -1,0 +1,57 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import Kappa
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = Kappa.LevelModel
+if useOnlyVF:
+    RD_model = None
+    LS_model = None
+    dissipation_model = 3
+    ME_model = 2
+else:
+    RD_model = 3
+    LS_model = 2
+    ME_model = 5
+    dissipation_model = 6
+
+dissipation_model_flag = 1
+if ct.useRANS >= 2:
+    dissipation_model_flag=2
+
+coefficients = Kappa.Coefficients(V_model=0+int(ct.movingDomain),
+                                  ME_model=ME_model+int(ct.movingDomain),
+                                  LS_model=LS_model+int(ct.movingDomain),
+                                  RD_model=RD_model+int(ct.movingDomain),
+                                  dissipation_model=dissipation_model+int(ct.movingDomain),
+                                  dissipation_model_flag=dissipation_model_flag+int(ct.movingDomain),#1 -- K-epsilon, 2 -- K-omega
+                                  useMetrics=useMetrics,
+                                  rho_0=rho_0,nu_0=nu_0,
+                                  rho_1=rho_1,nu_1=nu_1,
+                                  g=g,
+                                  c_mu=ct.opts.Cmu,sigma_k=ct.opts.sigma_k, 
+                                  sc_uref=kappa_sc_uref,
+                                  sc_beta=kappa_sc_beta)
+
+kInflow=ct.kInflow
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].k_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].k_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {},
+                                   1: {1: lambda x, flag: domain.bc[flag].k_diffusive.init_cython()},
+                                  }
+
+
+class ConstantIC:
+    def __init__(self,cval=0.0):
+        self.cval=cval
+    def uOfXT(self,x,t):
+        return self.cval
+
+   
+initialConditions  = {0:ConstantIC(cval=kInflow)}

--- a/2d/sediment/pipe_scour/ls_consrv_n.py
+++ b/2d/sediment/pipe_scour/ls_consrv_n.py
@@ -1,0 +1,78 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools,
+                     NumericalFlux)
+import ls_consrv_p as physics
+from proteus import Context
+from proteus.mprans.MCorr3P import DummyNewton
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+#time stepping
+runCFL = ct.runCFL
+timeIntegrator  = TimeIntegration.ForwardIntegrator
+timeIntegration = TimeIntegration.NoIntegration
+
+#mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0:ct.basis}
+
+subgridError      = None
+massLumping       = False
+numericalFluxType = ct.DoNothing
+conservativeFlux  = None
+shockCapturing    = None
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+#multilevelNonlinearSolver = DummyNewton
+#levelNonlinearSolver      = DummyNewton
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'mcorr_'
+nonlinearSolverConvergenceTest  = 'rits'
+levelNonlinearSolverConvergenceTest  = 'rits'
+linearSolverConvergenceTest  = 'r-true'
+
+tolFac = 0.0
+linTolFac = 0.01
+l_atol_res = 0.01*ct.mcorr_nl_atol_res
+nl_atol_res = ct.mcorr_nl_atol_res
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0

--- a/2d/sediment/pipe_scour/ls_consrv_p.py
+++ b/2d/sediment/pipe_scour/ls_consrv_p.py
@@ -1,0 +1,53 @@
+from proteus import StepControl
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import MCorr3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+
+LevelModelType = MCorr3P.LevelModel
+
+if ct.sedimentDynamics:
+    VOS_model=0
+    VOF_model=1
+    LS_model=2
+    MCORR_model=4
+    V_model=6
+else:
+    VOS_model=None
+    VOF_model=0
+    LS_model=1
+    MCORR_model=3
+    V_model=4
+
+coefficients = MCorr3P.Coefficients(LS_model=LS_model,
+                                    V_model=V_model,
+                                    ME_model=MCORR_model,
+                                    VOF_model=VOF_model,
+                                    VOS_model=VOS_model,
+                                    applyCorrection=ct.applyCorrection,
+                                    nd=nd,
+                                    checkMass=False,
+                                    useMetrics=ct.useMetrics,
+                                    epsFactHeaviside=ct.epsFact_consrv_heaviside,
+                                    epsFactDirac=ct.epsFact_consrv_dirac,
+                                    epsFactDiffusion=ct.epsFact_consrv_diffusion)
+
+class zero_phi:
+    def __init__(self):
+        pass
+    def uOfX(self,X):
+        return 0.0
+    def uOfXT(self,X,t):
+        return 0.0
+
+initialConditions  = {0:zero_phi()}

--- a/2d/sediment/pipe_scour/ls_n.py
+++ b/2d/sediment/pipe_scour/ls_n.py
@@ -1,0 +1,78 @@
+from proteus import StepControl
+from proteus.default_n import *
+import ls_p as physics
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+from proteus.mprans import NCLS3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+coefficients = physics.coefficients
+
+# time stepping
+runCFL = ct.runCFL
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_controller
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0: ct.basis}
+
+massLumping       = False
+conservativeFlux  = None
+numericalFluxType = NCLS3P.NumericalFlux
+subgridError      = NCLS3P.SubgridError(coefficients,nd)
+shockCapturing    = NCLS3P.ShockCapturing(coefficients,nd,shockCapturingFactor=ct.ls_shockCapturingFactor,lag=ct.ls_lag_shockCapturing)
+
+fullNewtonFlag  = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'ncls_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'r-true'
+
+tolFac = 0.0
+nl_atol_res = ct.ls_nl_atol_res
+linTolFac = 0.0
+l_atol_res = 0.1*ct.ls_nl_atol_res
+
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+
+auxiliaryVariables = ct.domain.auxiliaryVariables['ls']

--- a/2d/sediment/pipe_scour/ls_p.py
+++ b/2d/sediment/pipe_scour/ls_p.py
@@ -1,0 +1,48 @@
+from proteus import StepControl
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import NCLS3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+
+LevelModelType = NCLS3P.LevelModel
+
+if ct.sedimentDynamics:
+    LS_model=2
+    RD_model=3
+    V_model=6
+else:
+    LS_model=1
+    RD_model=2
+    V_model=4
+
+coefficients = NCLS3P.Coefficients(V_model=V_model,
+                                   RD_model=RD_model,
+                                   ME_model=LS_model,
+                                   checkMass=False,
+                                   useMetrics=ct.useMetrics,
+                                   epsFact=ct.epsFact_consrv_heaviside,
+                                   sc_uref=ct.ls_sc_uref,
+                                   sc_beta=ct.ls_sc_beta,
+                                   movingDomain=ct.movingDomain)
+
+dirichletConditions = {0: lambda x, flag: None}
+
+advectiveFluxBoundaryConditions = {}
+
+diffusiveFluxBoundaryConditions = {0: {}}
+
+class PHI_IC:
+    def uOfXT(self, x, t):
+        return x[nd-1] - ct.waterLevel
+
+initialConditions = {0: PHI_IC()}

--- a/2d/sediment/pipe_scour/pressureInitial_n.py
+++ b/2d/sediment/pipe_scour/pressureInitial_n.py
@@ -1,0 +1,54 @@
+from proteus import *
+from proteus.default_n import *
+from pressureInitial_p import *
+
+
+mesh = domain.MeshOptions
+triangleOptions = triangleOptions
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+
+femSpaces = {0:ct.pbasis}
+
+stepController=FixedStep
+
+#numericalFluxType = NumericalFlux.ConstantAdvection_Diffusion_SIPG_exterior #weak boundary conditions (upwind ?)
+matrix = LinearAlgebraTools.SparseMatrix
+
+#linearSmoother    = LinearSolvers.NavierStokesPressureCorrection # pure neumann laplacian solver
+#multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+#levelLinearSolver = LinearSolvers.KSP_petsc4py
+#linearSmoother    = None
+#multilevelLinearSolver = LinearSolvers.LU
+#levelLinearSolver      = LinearSolvers.LU
+numericalFluxType = NumericalFlux.ConstantAdvection_exterior
+#numericalFluxType = NumericalFlux
+
+linear_solver_options_prefix = 'pinit_'
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+else:
+    multilevelLinearSolver = KSP_petsc4py
+    levelLinearSolver      = KSP_petsc4py
+    parallelPartitioningType    = parallelPartitioningType
+    nLayersOfOverlapForParallel = nLayersOfOverlapForParallel
+    nonlinearSmoother = None
+    linearSmoother    = None
+
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+#linear solve rtolerance
+
+linTolFac = 0.0
+l_atol_res = 0.01*ct.phi_nl_atol_res
+tolFac = 0.0
+nl_atol_res = ct.phi_nl_atol_res
+nonlinearSolverConvergenceTest = 'r'
+levelNonlinearSolverConvergenceTest = 'r'
+linearSolverConvergenceTest             = 'r-true'
+maxLineSearches=0
+periodicDirichletConditions=None
+
+conservativeFlux=None

--- a/2d/sediment/pipe_scour/pressureInitial_p.py
+++ b/2d/sediment/pipe_scour/pressureInitial_p.py
@@ -1,0 +1,52 @@
+from math import *
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import PresInit
+from proteus import Context
+from tank import *
+
+ct = Context.get()
+name = "pressureInitial"
+
+if ct.sedimentDynamics:
+    V_model=6
+    PRESSURE_model=8
+    PINIT_model=9
+else:
+    V_model=4
+    PRESSURE_model=6
+    PINIT_model=7
+
+coefficients=PresInit.Coefficients(nd=nd,
+                                   modelIndex=PINIT_model,
+                                   fluidModelIndex=V_model,
+                                   pressureModelIndex=PRESSURE_model)
+
+#pressure increment should be zero on any pressure dirichlet boundaries
+
+#the advectiveFlux should be zero on any no-flow  boundaries
+
+
+class getIBC_pInit:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+class PerturbedSurface_p:
+    def __init__(self,waterLevel):
+        self.waterLevel=waterLevel
+    def uOfXT(self,x,t):
+        self.vos = ct.vos_function(x)
+        self.rho_a = rho_1#(1.-self.vos)*rho_1 + (self.vos)*ct.rho_s
+        self.rho_w = rho_0#(1.-self.vos)*rho_0 + (self.vos)*ct.rho_s
+        if signedDistance(x) < 0:
+            return -(L[1] - self.waterLevel)*self.rho_a*g[1] - (self.waterLevel - x[1])*self.rho_w*g[1]
+        else:
+            return -(L[1] - x[1])*self.rho_a*g[1]
+
+initialConditions = {0:PerturbedSurface_p(waterLine_z)} #getIBC_pInit()}
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].pInit_dirichlet.init_cython()}
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].pInit_advective.init_cython()}
+diffusiveFluxBoundaryConditions = {0:{0: lambda x, flag: domain.bc[flag].pInit_diffusive.init_cython()}}

--- a/2d/sediment/pipe_scour/pressure_n.py
+++ b/2d/sediment/pipe_scour/pressure_n.py
@@ -1,0 +1,53 @@
+from proteus import *
+from proteus.default_n import *
+from pressure_p import *
+
+
+mesh = domain.MeshOptions
+triangleOptions = triangleOptions
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+
+femSpaces = {0:ct.pbasis}
+
+
+# stepController  = StepControl.Min_dt_cfl_controller
+# runCFL= 0.99
+# runCFL= 0.5
+
+stepController=FixedStep
+
+#matrix type
+numericalFluxType = NumericalFlux.ConstantAdvection_exterior
+#numericalFluxType = NumericalFlux
+matrix = LinearAlgebraTools.SparseMatrix
+
+linear_solver_options_prefix = 'pressure_'
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+else:
+    multilevelLinearSolver = KSP_petsc4py
+    levelLinearSolver      = KSP_petsc4py
+    parallelPartitioningType    = parallelPartitioningType
+    nLayersOfOverlapForParallel = nLayersOfOverlapForParallel
+    nonlinearSmoother = None
+    linearSmoother    = None
+
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+#linear solve rtolerance
+
+linTolFac = 0.0
+l_atol_res = 0.1*ct.pressure_nl_atol_res
+tolFac = 0.0
+nl_atol_res = ct.pressure_nl_atol_res
+maxLineSearches = 0
+nonlinearSolverConvergenceTest      = 'r'
+levelNonlinearSolverConvergenceTest = 'r'
+linearSolverConvergenceTest         = 'r-true'
+
+periodicDirichletConditions=None
+
+conservativeFlux=None

--- a/2d/sediment/pipe_scour/pressure_p.py
+++ b/2d/sediment/pipe_scour/pressure_p.py
@@ -1,0 +1,44 @@
+from math import *
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import Pres
+from proteus import Context
+from tank import *
+
+ct = Context.get()
+name = "pressure"
+
+LevelModelType = Pres.LevelModel
+
+if ct.sedimentDynamics:
+    V_model=6
+    PINC_model=7
+    PRESSURE_model=8
+
+else:
+    V_model=4
+    PINC_model=5
+    PRESSURE_model=6
+
+coefficients=Pres.Coefficients(modelIndex=PRESSURE_model,
+                               fluidModelIndex=V_model,
+                               pressureIncrementModelIndex=PINC_model,
+                               useRotationalForm=True)
+
+
+class getIBC_p:
+    def __init__(self,waterLevel):
+        self.waterLevel=waterLevel
+    def uOfXT(self,x,t):
+        self.vos = ct.vos_function(x)
+        self.rho_a = rho_1#(1.-self.vos)*rho_1 + (self.vos)*ct.rho_s
+        self.rho_w = rho_0#(1.-self.vos)*rho_0 + (self.vos)*ct.rho_s
+        if signedDistance(x) < 0:
+            return -(L[1] - self.waterLevel)*self.rho_a*g[1] - (self.waterLevel - x[1])*self.rho_w*g[1]
+        else:
+            return -(L[1] - x[1])*self.rho_a*g[1]
+
+initialConditions = {0:getIBC_p(waterLine_z)}
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].p_dirichlet.init_cython() } # pressure bc are explicitly set
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].p_advective.init_cython()}

--- a/2d/sediment/pipe_scour/pressureincrement_n.py
+++ b/2d/sediment/pipe_scour/pressureincrement_n.py
@@ -1,0 +1,56 @@
+from proteus import *
+from proteus.default_n import *
+from pressureincrement_p import *
+
+mesh = domain.MeshOptions
+triangleOptions = triangleOptions
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+
+femSpaces = {0:pbasis}
+
+stepController=FixedStep
+
+#numericalFluxType = PresInc.NumericalFlux
+numericalFluxType = NumericalFlux.ConstantAdvection_exterior
+matrix = LinearAlgebraTools.SparseMatrix
+
+#if openTop:
+#    linearSmoother    = None
+#    multilevelLinearSolver = LinearSolvers.LU
+#    levelLinearSolver      = LinearSolvers.LU
+#else:
+#    linearSmoother         = LinearSolvers.NavierStokesPressureCorrection # pure neumann laplacian solver
+#    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+#    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+linear_solver_options_prefix = 'phi_'
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+else:
+    multilevelLinearSolver = KSP_petsc4py
+    levelLinearSolver      = KSP_petsc4py
+    parallelPartitioningType    = parallelPartitioningType
+    nLayersOfOverlapForParallel = nLayersOfOverlapForParallel
+    nonlinearSmoother = None
+    linearSmoother    = None
+
+
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+#linear solve rtolerance
+
+linTolFac = 0.0
+l_atol_res = 0.01*phi_nl_atol_res
+tolFac = 0.0
+nl_atol_res = phi_nl_atol_res
+nonlinearSolverConvergenceTest = 'r'
+levelNonlinearSolverConvergenceTest = 'r'
+linearSolverConvergenceTest             = 'r-true'
+maxLineSearches=0
+periodicDirichletConditions=None
+
+conservativeFlux = {0:'point-eval'} #'point-eval','pwl-bdm-opt'
+#conservativeFlux=None

--- a/2d/sediment/pipe_scour/pressureincrement_p.py
+++ b/2d/sediment/pipe_scour/pressureincrement_p.py
@@ -1,0 +1,63 @@
+from math import *
+from proteus import *
+from proteus.default_p import *
+from tank import *
+import tank_so
+from proteus.mprans import PresInc
+from proteus import Context
+
+ct = Context.get()
+
+if ct.sedimentDynamics:
+    VOS_model=0
+    VOF_model=1
+    V_model=6
+    SED_model=5
+    PINC_model=7
+else:
+    VOS_model=None
+    VOF_model=0
+    V_model=4
+    PINC_model=5
+    SED_model=None
+
+
+#domain = ctx.domain
+#nd = ctx.nd
+name = "pressureincrement"
+
+LevelModelType = PresInc.LevelModel
+#from ProjectionScheme import PressureIncrement
+#coefficients=PressureIncrement(rho_f_min = rho_1,
+#                               rho_s_min = rho_s,
+#                               nd = nd,
+#                               modelIndex=PINC_model,
+#                               fluidModelIndex=V_model)
+from proteus.mprans import PresInc
+coefficients=PresInc.Coefficients(rho_f_min = (1.0-1.0e-8)*rho_1,
+                                  rho_s_min = (1.0-1.0e-8)*rho_s,
+                                  nd = nd,
+                                  modelIndex= PINC_model,
+                                  fluidModelIndex= V_model,
+                                  sedModelIndex= SED_model,
+                                  VOF_model= VOF_model,
+                                  VOS_model= VOS_model,
+                                  fixNullSpace=fixNullSpace_PresInc, 
+                                  INTEGRATE_BY_PARTS_DIV_U=ct.INTEGRATE_BY_PARTS_DIV_U_PresInc)
+
+
+#pressure increment should be zero on any pressure dirichlet boundaries
+
+#the advectiveFlux should be zero on any no-flow  boundaries
+
+class getIBC_phi:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+initialConditions = {0:getIBC_phi()}
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].pInc_dirichlet.init_cython()}
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].pInc_advective.init_cython()}
+diffusiveFluxBoundaryConditions = {0:{0: lambda x, flag: domain.bc[flag].pInc_diffusive.init_cython()}}

--- a/2d/sediment/pipe_scour/redist_n.py
+++ b/2d/sediment/pipe_scour/redist_n.py
@@ -1,0 +1,95 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools,
+                     NumericalFlux)
+from proteus.mprans import RDLS3P
+import redist_p as physics
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+# time stepping
+runCFL = ct.runCFL
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0: ct.basis}
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+massLumping       = False
+numericalFluxType = NumericalFlux.DoNothing
+conservativeFlux  = None
+subgridError      = RDLS3P.SubgridError(physics.coefficients,nd)
+shockCapturing    = RDLS3P.ShockCapturing(physics.coefficients,nd,shockCapturingFactor=ct.rd_shockCapturingFactor,lag=ct.rd_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver  = NonlinearSolvers.Newton
+levelNonlinearSolver       = NonlinearSolvers.Newton
+
+nonlinearSmoother = NonlinearSolvers.NLGaussSeidel
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+if ct.redist_Newton:
+    timeIntegration = NoIntegration
+    stepController = ct.Newton_controller
+    maxNonlinearIts = 50
+    maxLineSearches = 0
+    nonlinearSolverConvergenceTest = 'rits'
+    levelNonlinearSolverConvergenceTest = 'rits'
+    linearSolverConvergenceTest = 'r-true'
+    useEisenstatWalker = False
+else:
+    timeIntegration = BackwardEuler_cfl
+    stepController = RDLS3P.PsiTC
+    runCFL=2.0
+    psitc['nStepsForce']=3
+    psitc['nStepsMax']=50
+    psitc['reduceRatio']=10.0
+    psitc['startRatio']=1.0
+    rtol_res[0] = 0.0
+    atol_res[0] = rd_nl_atol_res
+    useEisenstatWalker = False#True
+    maxNonlinearIts = 1
+    maxLineSearches = 0
+    nonlinearSolverConvergenceTest = 'rits'
+    levelNonlinearSolverConvergenceTest = 'rits'
+    linearSolverConvergenceTest = 'r-true'
+
+linear_solver_options_prefix = 'rdls_'
+
+tolFac = 0.0
+nl_atol_res = ct.rd_nl_atol_res
+linTolFac = 0.01
+l_atol_res = 0.01*ct.rd_nl_atol_res
+useEisenstatWalker = False#True

--- a/2d/sediment/pipe_scour/redist_p.py
+++ b/2d/sediment/pipe_scour/redist_p.py
@@ -1,0 +1,52 @@
+from proteus import StepControl
+from proteus import *
+from proteus.default_p import *
+from math import *
+from proteus.mprans import RDLS3P
+from proteus import Context
+
+"""
+The redistancing equation in the sloshbox test problem.
+"""
+
+ct = Context.get()
+domain = ct.domain
+nd = domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+
+LevelModelType = RDLS3P.LevelModel
+
+if ct.sedimentDynamics:
+    LS_model=2
+    RD_model=3
+else:
+    LS_model=1
+    RD_model=2
+
+
+coefficients = RDLS3P.Coefficients(applyRedistancing=ct.applyRedistancing,
+                                   epsFact=ct.epsFact_redistance,
+                                   nModelId=LS_model,
+                                   rdModelId=RD_model,
+                                   useMetrics=ct.useMetrics,
+                                   backgroundDiffusionFactor=ct.backgroundDiffusionFactor)
+
+def getDBC_rd(x,flag):
+    pass
+
+dirichletConditions     = {0:getDBC_rd}
+weakDirichletConditions = {0:RDLS3P.setZeroLSweakDirichletBCsSimple}
+
+advectiveFluxBoundaryConditions =  {}
+diffusiveFluxBoundaryConditions = {0:{}}
+
+class PHI_IC:
+    def uOfXT(self, x, t):
+        return x[nd-1] - ct.waterLevel
+
+initialConditions  = {0: PHI_IC()}

--- a/2d/sediment/pipe_scour/tank.py
+++ b/2d/sediment/pipe_scour/tank.py
@@ -1,0 +1,611 @@
+from proteus import StepControl
+from math import *
+import proteus.MeshTools
+from proteus import Domain, Context
+from proteus.default_n import *
+from proteus.Profiling import logEvent
+from proteus.mprans import SpatialTools as st
+from proteus import Gauges as ga
+from proteus import WaveTools as wt
+from proteus.mprans.SedClosure import  HsuSedStress
+from proteus.mprans import BoundaryConditions as bc
+
+from proteus.mprans import BodyDynamics as bd
+
+opts=Context.Options([
+	# TANK PARAMETERS
+	("tank_dim_x", 1.6, "x_dim"),
+    ("tank_dim_y", 0.6, "y_dim"),
+    ("hole_tank", True, "hole"),
+    ("dtout", 0.05, "Time interval for output"),
+    ("waterLevel" , 0.35+0.16, "waterLevel"),
+    #fluid parameters
+    ("rho_0", 998.2, "water density"),
+    ("rho_1", 998.2, "air density"),
+    ("nu_0", 1.004e-6, "water kin viscosity"),
+    ("nu_1", 1.004e-6, "air kin viscosity"),
+    ('g',np.array([0.0, -9.8, 0.0]),'Gravitational acceleration'),    
+    # current
+    ("current",True, "yes or no"),
+    ("inflow_vel", 1e-10, "inflow velocity"),
+    ("GenZone", not True, "on/off"),
+    ("AbsZone", not True, "on/off"),
+    # cylinder
+	
+    ("cylinder_radius", 0.05, "radius of cylinder"),
+    ("cylinder_pos_x", 0.8, "x position of cylinder"),
+    ("cylinder_pos_y", 0.085+0.05+0.16, "y position of cylinder"),
+    ("circle2D", True, "switch on/off cylinder"),
+    ("circleBC", 'NoSlip','circle BC'),
+    # sediment parameters
+    ('cSed', 0.6,'Sediment concentration'),
+    ('rho_s',2600.0 ,'sediment material density'),
+    ('alphaSed', 150.,'laminar drag coefficient'),
+    ('betaSed', 0.0,'turbulent drag coefficient'),
+    ('grain',0.0025, 'Grain size'),
+    ('packFraction',0.2,'threshold for loose / packed sediment'),
+    ('packMargin',0.01,'transition margin for loose / packed sediment'),
+    ('maxFraction',0.635,'fraction at max  sediment packing'),
+    ('frFraction',0.57,'fraction where contact stresses kick in'),
+    ('sigmaC',1.1,'Schmidt coefficient for turbulent diffusion'),
+    ('C3e',1.2,'Dissipation coefficient '),
+    ('C4e',1.0,'Dissipation coefficient'),
+    ('eR', 0.8, 'Collision stress coefficient (module not functional)'),
+    ('fContact', 0.05,'Contact stress coefficient'),
+    ('mContact', 3.0,'Contact stress coefficient'),
+    ('nContact', 5.0,'Contact stress coefficient'),
+    ('angFriction', pi/6., 'Angle of friction'),
+    ('vos_limiter', 0.62, 'Weak limiter for vos'),
+    ('mu_fr_limiter', 1e-3,'Hard limiter for contact stress friction coeff'),
+    # numerical options
+    ("he", 0.04,"he"),
+	("refinement", 4, "refinement"),
+    ("sedimentDynamics", True, "Enable sediment dynamics module"),
+    ("openTop",  True, "Enable open atmosphere for air phase on the top"),
+    ("cfl", 0.25 ,"Target cfl"),
+    ("duration", 1.0 ,"Duration of the simulation"),
+    ("PSTAB", 1.0, "Affects subgrid error"),
+    ("res", 1.0e-10, "Residual tolerance"),
+    ("epsFact_density", 3.0, "Control width of water/air transition zone"),
+    ("epsFact_consrv_diffusion", 1.0, "Affects smoothing diffusion in mass conservation"),
+    ("vos_SC",0.9,"vos shock capturing"),
+    ("useRANS", 0, "Switch ON turbulence models: 0-None, 1-K-Epsilon, 2-K-Omega1998, 3-K-Omega1988"), # ns_closure: 1-classic smagorinsky, 2-dynamic smagorinsky, 3-k-epsilon, 4-k-omega
+    ("sigma_k", 1.0, "sigma_k coefficient for the turbulence model"),
+    ("sigma_e", 1.0, "sigma_e coefficient for the turbulence model"),
+    ("K", 0.41, "von Karman coefficient for the turbulence model"),
+    ("B", 5.57, "Wall coefficient for the turbulence model"),
+    ("Cmu", 0.09, "Cmu coefficient for the turbulence model"),
+    ])
+
+# SO Models
+
+VOS_model = 0
+VOF_model = 1
+LS_model = 2
+RD_model = 3
+MCORR_model =4
+SED_model =5
+V_model =6
+DP_model = 7
+P_model = 8
+
+
+if opts.useRANS:
+    K_model = 9
+    EPS_model = 10
+    PI_model = 11
+else:
+    K_model = None
+    EPS_model = None   
+    PI_model = 9
+
+# Domain dimensions
+
+nd = 2
+
+# Turbulence and wall functions
+
+
+steady_current = wt.SteadyCurrent(U=np.array([opts.inflow_vel,0.,0.]),mwl=opts.waterLevel,rampTime=0.8)
+#I = opts.I
+#kInflow = 0.5*(opts.inflow_vel*I)**2
+#Lturb = opts.Ly/6.
+#dissipationInflow = (opts.Cmu**0.75) *(kInflow**1.5)/Lturb
+
+#Wall functions
+
+he = opts.tank_dim_y/opts.refinement
+Re = opts.inflow_vel*opts.tank_dim_y/opts.nu_0
+Y_ = he
+cf = 0.045*(Re**(-1./4.))
+Ut = opts.inflow_vel*sqrt(cf/2.)
+Yplus = Y_*Ut/opts.nu_0
+kappaP = (Ut**2)/sqrt(opts.Cmu)
+dissipationP = (Ut**3)/(opts.K*Y_)
+# ----- Sediment stress ----- #
+
+sedClosure = HsuSedStress(aDarcy =  opts.alphaSed,
+                          betaForch =  opts.betaSed,
+                          grain =  opts.grain,
+                          packFraction =  opts.packFraction,
+                          packMargin =  opts.packMargin,
+                          maxFraction =  opts.maxFraction,
+                          frFraction =  opts.frFraction,
+                          sigmaC =  opts.sigmaC,
+                          C3e =  opts.C3e,
+                          C4e =  opts.C4e,
+                          eR =  opts.eR,
+                          fContact =  opts.fContact,
+                          mContact =  opts.mContact,
+                          nContact =  opts.nContact,
+                          angFriction =  opts.angFriction,
+                          vos_limiter = opts.vos_limiter,
+                          mu_fr_limiter = opts.mu_fr_limiter,
+                          )
+
+# ----- DOMAIN ----- #
+
+domain = Domain.PlanarStraightLineGraphDomain()
+
+
+# ----- Phisical constants ----- #
+  
+# Water
+rho_0 = opts.rho_0
+nu_0 = opts.nu_0
+
+# Air
+rho_1 = opts.rho_1
+nu_1 = opts.nu_1
+
+# Sediment
+
+rho_s = opts.rho_s
+nu_s = 1000000
+dragAlpha = 0.0
+
+# Surface tension
+sigma_01 = 0.0
+
+# Gravity
+g = opts.g
+gamma_0 = abs(g[1])*rho_0
+
+# Initial condition
+waterLevel = opts.waterLevel 
+waterLine_z=opts.waterLevel
+sediment_level = waterLevel-0.6
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Domain and mesh
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+he = opts.he
+
+############ TANK ###################
+
+
+
+tank_dim = (opts.tank_dim_x, opts.tank_dim_y)
+
+x1=0.2
+
+### CYLINDER #####
+cylinder_pos = np.array([opts.cylinder_pos_x, opts.cylinder_pos_y, 0.])
+cylinder_radius = opts.cylinder_radius
+
+if opts.circle2D:
+    circle = st.Circle(domain=domain, radius=cylinder_radius, coords=(cylinder_pos[0],cylinder_pos[1]), barycenter=(cylinder_pos[0],cylinder_pos[1]), nPoints=28)
+
+    circle2D = bd.RigidBody(shape=circle)
+    free_x = (0.0,0.0,0.0)
+    free_r = (0.0,0.0,0.0)
+    circle2D.setConstraints(free_x=free_x,free_r=free_r)
+    circle2D.setNumericalScheme(None)
+    circle2D.setRecordValues(filename='circle2D',all_values=True)
+
+boundaryOrientations = {'y-': np.array([0., -1.,0.]),
+                        'x+': np.array([+1, 0.,0.]),
+                        'y+': np.array([0., +1.,0.]),
+                        'x-': np.array([-1., 0.,0.]),
+                        'sponge': None,
+                        'circle': None,
+                        'hole_x-': np.array([-1., 0.,0.]),
+                        'hole_x+': np.array([+1., 0.,0.]),
+                        'hole_y-': np.array([0., -1.,0.]),
+                           }
+
+boundaryTags = {'y-': 1,
+                    'x+': 2,
+                    'y+': 3,
+                    'x-': 4,
+                    'sponge': 5,
+                    'circle':6,
+                    'hole_x-':7,
+                    'hole_x+':8,
+                    'hole_y-':9,
+                       }
+
+if opts.hole_tank:
+
+    vertices=[[0.0, 0.24],#0
+              [x1,  0.24],#1
+              [0.3,  0.24],#2
+              [0.3,  0.0],#3
+              [1.3,  0.0],#4
+              [1.3,  0.24],#5
+              [1.4,  0.24],#6
+              [tank_dim[0],0.24],#7
+              [tank_dim[0],tank_dim[1]+0.16], #8
+              [1.4, tank_dim[1]+0.16], #9
+              [0.2, tank_dim[1]+0.16], #10
+              [0.0, tank_dim[1]+0.16], #11
+              ]
+
+    vertexFlags=np.array([1, 1, 1,
+                          9, 9,
+                          1, 1, 1,
+                          3, 3, 3, 3,
+                          ])
+    segments=[[0,1],
+              [1,2],
+
+              [2,3],
+              [3,4],
+              [4,5],
+
+              [5,6],
+              [6,7],
+
+              [7,8],
+
+              [8,9],
+              [9,10],
+              [10,11],
+
+              [11,0],
+
+              [1,10],
+              [6,9],
+             ]
+
+    segmentFlags=np.array([ 1, 1, 
+                            7, 9, 8,
+                            1, 1,
+                            2,
+                            3, 3, 3, 
+                            4,
+                            5, 5,
+                         ])
+
+
+regions = [ [ 0.90*x1 , 0.50*tank_dim[1] ],
+            [ 0.7 , 0.50*tank_dim[1] ],
+            [ 0.95*tank_dim[0] , 0.50*tank_dim[1] ] ]
+
+regionFlags=np.array([1, 2, 3])
+
+
+tank = st.CustomShape(domain, vertices=vertices, vertexFlags=vertexFlags,
+                      segments=segments, segmentFlags=segmentFlags,
+                      regions=regions, regionFlags=regionFlags,
+                      boundaryTags=boundaryTags, boundaryOrientations=boundaryOrientations)
+
+#############################################################################################################################################################################################################################################################################################################################################################################################
+# ----- BOUNDARY CONDITIONS ----- #
+#############################################################################################################################################################################################################################################################################################################################################################################################
+
+if opts.circle2D:
+  
+    for bc in circle.BC_list:
+        if opts.circleBC == 'FreeSlip':
+            bc.setFreeSlip()
+        if opts.circleBC == 'NoSlip':
+            bc.setNoSlip()
+
+tank.BC['y-'].setFreeSlip()
+tank.BC['y+'].setFreeSlip()#.setAtmosphere(orientation=np.array([0., +1.,0.]),kInflow=kInflow,dInflow=dissipationInflow)
+
+tank.BC['x-'].setUnsteadyTwoPhaseVelocityInlet(wave=steady_current, smoothing = 3*he, vert_axis=1)
+tank.BC['x-'].pInit_advective.setConstantBC(0.0)
+tank.BC['x-'].pInit_diffusive.setConstantBC(0.0)
+tank.BC['x-'].pInc_diffusive.setConstantBC(0.0)
+tank.BC['x-'].pInc_advective.uOfXT = lambda x,t: -opts.inflow_vel
+tank.BC['x-'].p_advective.setConstantBC(0.0)
+
+tank.BC['x+'].setHydrostaticPressureOutletWithDepth(seaLevel=opts.waterLevel, rhoUp=rho_1, rhoDown = rho_0, g=g, refLevel= tank_dim[1], smoothing = 3*he)
+    
+tank.BC['x+'].u_dirichlet.uOfXT = None
+tank.BC['x+'].v_dirichlet.uOfXT = None
+tank.BC['x+'].u_advective.setConstantBC(0.0)
+tank.BC['x+'].v_advective.setConstantBC(0.0)
+tank.BC['x+'].u_diffusive.setConstantBC(0.0)
+tank.BC['x+'].v_diffusive.setConstantBC(0.0)
+tank.BC['x+'].pInc_dirichlet.setConstantBC(0.0) 
+
+tank.BC['hole_x+'].setFreeSlip()
+tank.BC['hole_x-'].setFreeSlip()
+tank.BC['hole_y-'].setFreeSlip()
+tank.BC['hole_y-'].vos_dirichlet.setConstantBC(opts.cSed)
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Turbulence
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+if opts.useRANS:
+    kInflow = 1e-6
+    dissipationInflow = 1e-6
+    tank.BC['x-'].setTurbulentZeroGradient()
+    tank.BC['x+'].setTurbulentZeroGradient()
+    tank.BC['y-'].setTurbulentZeroGradient()
+    tank.BC['y+'].setTurbulentZeroGradient()
+
+######################################################################################################################################################################################################################
+# Gauges and probes #
+######################################################################################################################################################################################################################
+
+T=opts.duration
+PG = []
+gauge_dy=0.01
+tank_dim_y=opts.tank_dim_y
+nprobes=int(tank_dim_y/gauge_dy)+1
+probes=np.linspace(0., tank_dim_y, nprobes)
+for i in probes:
+    PG.append((opts.tank_dim_x/2., i, 0.),)
+v_output = ga.PointGauges(gauges=((('u',), PG),
+                                  (('v',), PG),),
+                          activeTime = (0., T),
+                          sampleRate=0.,
+                          fileName='fluidVelocityGauges.csv')
+vs_output = ga.PointGauges(gauges=((('us',),PG), 
+                                   (('vs',),PG),),
+                          activeTime = (0., T),
+                          sampleRate=0.,
+                          fileName='solidVelocityGauges.csv')
+vos_output = ga.PointGauges(gauges=((('vos',),PG),),
+                          activeTime = (0., T),
+                          sampleRate=0.,
+                          fileName='solidFractionGauges.csv')
+
+######################################################################################################################################################################################################################
+# Numerical Options and other parameters #
+######################################################################################################################################################################################################################
+ 
+domain.MeshOptions.he = he
+
+from math import *
+from proteus import MeshTools, AuxiliaryVariables
+import numpy
+import proteus.MeshTools
+from proteus import Domain
+from proteus.Profiling import logEvent
+from proteus.default_n import *
+from proteus.ctransportCoefficients import smoothedHeaviside
+from proteus.ctransportCoefficients import smoothedHeaviside_integral
+
+st.assembleDomain(domain)
+
+
+#----------------------------------------------------
+# Time stepping and velocity
+#----------------------------------------------------
+
+T=opts.duration
+weak_bc_penalty_constant = 10.0/nu_0 #100
+dt_fixed = opts.dtout
+dt_init = min(0.1*dt_fixed,0.001)
+nDTout= int(round(T/dt_fixed))
+runCFL = opts.cfl
+
+sedimentDynamics=opts.sedimentDynamics
+
+#----------------------------------------------------
+#  Discretization -- input options
+#----------------------------------------------------
+
+genMesh = True
+movingDomain = False
+applyRedistancing = True
+useOldPETSc = False
+useSuperlu = False
+timeDiscretization = 'be'#'vbdf'#'vbdf'  # 'vbdf', 'be', 'flcbdf'
+spaceOrder = 1
+pspaceOrder = 1
+useHex = False
+useRBLES = 0.0
+useMetrics = 1.0
+applyCorrection = True
+useVF = 1.0
+useOnlyVF = False
+useRANS = opts.useRANS  # 0 -- None
+                        # 1 -- K-Epsilon
+                        # 2 -- K-Omega
+
+
+KILL_PRESSURE_TERM = False
+fixNullSpace_PresInc = True
+INTEGRATE_BY_PARTS_DIV_U_PresInc = True
+CORRECT_VELOCITY = True
+STABILIZATION_TYPE = 0 #0: SUPG, 1: EV via weak residual, 2: EV via strong residual
+
+# Input checks
+if spaceOrder not in [1, 2]:
+    print "INVALID: spaceOrder" + spaceOrder
+    sys.exit()
+
+if useRBLES not in [0.0, 1.0]:
+    print "INVALID: useRBLES" + useRBLES
+    sys.exit()
+
+if useMetrics not in [0.0, 1.0]:
+    print "INVALID: useMetrics"
+    sys.exit()
+
+#  Discretization
+nd = tank.nd
+
+if spaceOrder == 1:
+    hFactor = 1.0
+    if useHex:
+        basis = C0_AffineLinearOnCubeWithNodalBasis
+        elementQuadrature = CubeGaussQuadrature(nd, 2)
+        elementBoundaryQuadrature = CubeGaussQuadrature(nd - 1, 2)
+    else:
+        basis = C0_AffineLinearOnSimplexWithNodalBasis
+        elementQuadrature = SimplexGaussQuadrature(nd, 3)
+        elementBoundaryQuadrature = SimplexGaussQuadrature(nd - 1, 3)
+elif spaceOrder == 2:
+    hFactor = 0.5
+    if useHex:
+        basis = C0_AffineLagrangeOnCubeWithNodalBasis
+        elementQuadrature = CubeGaussQuadrature(nd, 4)
+        elementBoundaryQuadrature = CubeGaussQuadrature(nd - 1, 4)
+    else:
+        basis = C0_AffineQuadraticOnSimplexWithNodalBasis
+        elementQuadrature = SimplexGaussQuadrature(nd, 4)
+        elementBoundaryQuadrature = SimplexGaussQuadrature(nd - 1, 4)
+
+if pspaceOrder == 1:
+    if useHex:
+        pbasis = C0_AffineLinearOnCubeWithNodalBasis
+    else:
+        pbasis = C0_AffineLinearOnSimplexWithNodalBasis
+elif pspaceOrder == 2:
+    if useHex:
+        pbasis = C0_AffineLagrangeOnCubeWithNodalBasis
+    else:
+        pbasis = C0_AffineQuadraticOnSimplexWithNodalBasis
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Numerical parameters
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+ns_forceStrongDirichlet = False
+ns_sed_forceStrongDirichlet = False
+backgroundDiffusionFactor=0.01
+
+if useMetrics:
+    ns_shockCapturingFactor = 0.5
+    ns_lag_shockCapturing = True
+    ns_lag_subgridError = True
+    ns_sed_shockCapturingFactor = 0.5
+    ns_sed_lag_shockCapturing = True
+    ns_sed_lag_subgridError = True
+    ls_shockCapturingFactor = 0.5
+    ls_lag_shockCapturing = True
+    ls_sc_uref = 1.0
+    ls_sc_beta = 1.0
+    vof_shockCapturingFactor = 0.5
+    vof_lag_shockCapturing = True
+    vof_sc_uref = 1.0
+    vof_sc_beta = 1.0
+    vos_shockCapturingFactor =  opts.vos_SC # <------------------------------------- 
+    vos_lag_shockCapturing = True
+    vos_sc_uref = 1.0
+    vos_sc_beta = 1.0
+    rd_shockCapturingFactor = 0.5
+    rd_lag_shockCapturing = False
+    epsFact_vos =opts.epsFact_density
+    epsFact_density = opts.epsFact_density # 1.5
+    epsFact_viscosity = epsFact_curvature = epsFact_vof = epsFact_consrv_heaviside = epsFact_consrv_dirac = epsFact_density
+    epsFact_redistance = 0.33
+    epsFact_consrv_diffusion = opts.epsFact_consrv_diffusion # 0.1
+    redist_Newton = True
+    kappa_shockCapturingFactor = 0.5
+    kappa_lag_shockCapturing = True #False
+    kappa_sc_uref = 1.0
+    kappa_sc_beta = 1.5
+    dissipation_shockCapturingFactor = 0.5
+    dissipation_lag_shockCapturing = True #False
+    dissipation_sc_uref = 1.0
+    dissipation_sc_beta = 1.5
+else:
+    ns_shockCapturingFactor = 0.9
+    ns_lag_shockCapturing = True
+    ns_lag_subgridError = True
+    ns_sed_shockCapturingFactor = 0.9
+    ns_sed_lag_shockCapturing = True
+    ns_sed_lag_subgridError = True
+    ls_shockCapturingFactor = 0.9
+    ls_lag_shockCapturing = True
+    ls_sc_uref = 1.0
+    ls_sc_beta = 1.0
+    vof_shockCapturingFactor = 0.9
+    vof_lag_shockCapturing = True
+    vof_sc_uref = 1.0
+    vof_sc_beta = 1.0
+    vos_shockCapturingFactor = .9
+    vos_lag_shockCapturing = True
+    vos_sc_uref = 1.0
+    vos_sc_beta = 1.0
+    rd_shockCapturingFactor = 0.9
+    rd_lag_shockCapturing = False
+    epsFact_density = opts.epsFact_density # 1.5
+    epsFact_viscosity = epsFact_curvature = epsFact_vof = epsFact_vos = epsFact_consrv_heaviside = epsFact_consrv_dirac = epsFact_density
+    epsFact_redistance = 0.33
+    epsFact_consrv_diffusion = opts.epsFact_consrv_diffusion # 1.0
+    redist_Newton = False
+    kappa_shockCapturingFactor = 0.5
+    kappa_lag_shockCapturing = True  #False
+    kappa_sc_uref = 1.0
+    kappa_sc_beta = 1.5
+    dissipation_shockCapturingFactor = 0.5
+    dissipation_lag_shockCapturing = True  #False
+    dissipation_sc_uref = 1.0
+    dissipation_sc_beta = 1.5
+
+ns_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+ns_sed_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+vof_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+vos_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+ls_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+rd_nl_atol_res =  max(opts.res, 0.005 * he)
+mcorr_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+kappa_nl_atol_res = max(1.0e-12,0.001*he**2)
+dissipation_nl_atol_res = max(1.0e-12,0.001*he**2)
+phi_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+pressure_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Turbulence
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+ns_closure = 0  #1-classic smagorinsky, 2-dynamic smagorinsky, 3 -- k-epsilon, 4 -- k-omega
+ns_sed_closure = 0  #1-classic smagorinsky, 2-dynamic smagorinsky, 3 -- k-epsilon, 4 -- k-omega
+if useRANS == 1:
+    ns_closure = 3
+elif useRANS == 2:
+    ns_closure == 4
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Functions for model variables - Initial conditions
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+def signedDistance(x):
+    phi_z = x[1] - waterLine_z
+    return phi_z
+
+def vos_signedDistance(x):
+    phi_z = x[1] - 0.75*waterLine_z
+    return phi_z
+
+class Suspension_class:
+    def __init__(self):
+        pass
+    def uOfXT(self, x, t=0):
+        phi = vos_signedDistance(x)
+        smoothing = (epsFact_consrv_heaviside)*he/2.
+        Heav = smoothedHeaviside(smoothing, phi)      
+        if phi <= -smoothing:
+            return opts.cSed
+        elif -smoothing < phi < smoothing:
+            return opts.cSed * (1.-Heav)            
+        else:
+            return 1e-10    
+
+Suspension = Suspension_class()
+
+vos_function = Suspension.uOfXT

--- a/2d/sediment/pipe_scour/tank_old.py
+++ b/2d/sediment/pipe_scour/tank_old.py
@@ -1,0 +1,638 @@
+from proteus import StepControl
+from math import *
+import proteus.MeshTools
+from proteus import Domain, Context
+from proteus.default_n import *
+from proteus.Profiling import logEvent
+from proteus.mprans import SpatialTools as st
+from proteus import Gauges as ga
+from proteus import WaveTools as wt
+from proteus.mprans.SedClosure import  HsuSedStress
+from proteus.mbd import CouplingFSI as crb
+from proteus.mbd import pyChronoCore as pych
+#from proteus.ctransportCoefficients import smoothedHeaviside 
+#from proteus.ctransportCoefficients import smoothedHeaviside_integral
+from proteus.mprans import BodyDynamics as bd
+
+
+opts=Context.Options([
+    # predefined test cases
+    #("waterLine_x", 10.00, "Width of free surface from left to right"),
+    #("waterLine_z", 1., "Heigth of free surface above bottom"),
+    #("Lx", 1.50, "Length of the numerical domain"),
+    #("Ly", 1.5, "Heigth of the numerical domain"),
+    ("dtout", 0.05, "Time interval for output"),
+    ("Refiment", 4, "refinement"),
+    ("tank_dim_x", 1.6, "x_dim"),
+    ("tank_dim_y", 0.6, "y_dim"),
+    ("hole_tank", True, "hole"),
+    ("waterLevel" , 0.35+0.16, "waterLevel"),
+    # current
+    ("current",True, "yes or no"),
+    ("inflow_vel", 1e-10, "inflow velocity"),
+    ("GenZone", not True, "on/off"),
+    ("AbsZone", not True, "on/off"),
+    # cylinder
+    ("cylinder_radius", 0.05, "radius of cylinder"),
+    ("cylinder_pos_x", 0.8, "x position of cylinder"),
+    ("cylinder_pos_y", 0.085+0.05+0.16, "y position of cylinder"),
+    ("circle2D", True, "switch on/off cylinder"),
+    ("circleBC", 'NoSlip','circle BC'),
+    # sediment parameters
+    ('cSed', 0.6,'Sediment concentration'),
+    # numerical options
+    ("he", 0.04,"he"),
+    ("sedimentDynamics", True, "Enable sediment dynamics module"),
+    ("openTop",  True, "Enable open atmosphere for air phase on the top"),
+    ("cfl", 0.25 ,"Target cfl"),
+    ("duration", 1.0 ,"Duration of the simulation"),
+    ("PSTAB", 1.0, "Affects subgrid error"),
+    ("res", 1.0e-10, "Residual tolerance"),
+    ("epsFact_density", 3.0, "Control width of water/air transition zone"),
+    ("epsFact_consrv_diffusion", 1.0, "Affects smoothing diffusion in mass conservation"),
+    ("vos_SC",0.9,"vos shock capturing"),
+    ("useRANS", 0, "Switch ON turbulence models: 0-None, 1-K-Epsilon, 2-K-Omega1998, 3-K-Omega1988"), # ns_closure: 1-classic smagorinsky, 2-dynamic smagorinsky, 3-k-epsilon, 4-k-omega
+    ("sigma_k", 1.0, "sigma_k coefficient for the turbulence model"),
+    ("sigma_e", 1.0, "sigma_e coefficient for the turbulence model"),
+    ("Cmu", 0.09, "Cmu coefficient for the turbulence model"),
+    ])
+
+
+steady_current = wt.SteadyCurrent(U=[opts.inflow_vel,0,0],mwl=opts.waterLevel,rampTime=0.8)
+
+
+# ----- Sediment stress ----- #
+
+sedClosure = HsuSedStress(aDarcy =  150.0,
+                          betaForch =  0.0,
+                          grain =  0.0025,
+                          packFraction =  0.2,
+                          packMargin =  0.01,
+                          maxFraction =  0.635,
+                          frFraction =  0.57,
+                          sigmaC =  1.1,
+                          C3e =  1.2,
+                          C4e =  1.0,
+                          eR =  0.8,
+                          fContact =  0.05,
+                          mContact =  3.0,
+                          nContact =  5.0,
+                          angFriction =  pi/6.,
+                          vos_limiter = 0.62,
+                          mu_fr_limiter = 1e-3,
+                          )
+
+# ----- DOMAIN ----- #
+
+domain = Domain.PlanarStraightLineGraphDomain()
+
+
+
+
+
+
+
+# ----- Phisical constants ----- #
+  
+# Water
+rho_0 = 998.2
+nu_0 = 1.004e-6
+
+# Air
+rho_1 = rho_0 # 1.205 #
+nu_1 =  nu_0 #1.500e-5 # 
+
+# Sediment
+
+rho_s = 2600.0 # rho_0
+nu_s = 1000000.0 # 0.0 # nu_0 # 
+dragAlpha = 0.0
+
+# Surface tension
+sigma_01 = 0.0
+
+# Gravity
+g = np.array([0.0, -9.8, 0.0])
+gamma_0 = abs(g[1])*rho_0
+
+# Initial condition
+#waterLine_x = opts.waterLine_x
+#waterLine_z = opts.waterLine_z
+waterLevel = opts.waterLevel 
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Domain and mesh
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+#L = (opts.Lx, opts.Ly)
+#he = L[0]/opts.refinement
+he = opts.he
+#dim = dimx, dimy = L
+#coords = [ dimx/2., dimy/2. ]
+
+############ TANK ###################
+
+
+
+tank_dim = (opts.tank_dim_x, opts.tank_dim_y)
+
+x1=0.2
+
+
+
+
+### CYLINDER #####
+cylinder_pos = np.array([opts.cylinder_pos_x, opts.cylinder_pos_y, 0.])
+cylinder_radius = opts.cylinder_radius
+
+
+
+
+
+if opts.circle2D:
+    circle = st.Circle(domain=domain, radius=cylinder_radius, coords=(cylinder_pos[0],cylinder_pos[1]), barycenter=(cylinder_pos[0],cylinder_pos[1]), nPoints=28)
+
+    circle2D = bd.RigidBody(shape=circle)
+    free_x = (0.0,0.0,0.0)
+    free_r = (0.0,0.0,0.0)
+    circle2D.setConstraints(free_x=free_x,free_r=free_r)
+    circle2D.setNumericalScheme(None)
+    circle2D.setRecordValues(filename='circle2D',all_values=True)
+
+
+
+
+
+boundaryOrientations = {'y-': np.array([0., -1.,0.]),
+                        'x+': np.array([+1, 0.,0.]),
+                        'y+': np.array([0., +1.,0.]),
+                        'x-': np.array([-1., 0.,0.]),
+                        'sponge': None,
+                        'circle': None,
+                        'hole_x-': np.array([-1., 0.,0.]),
+                        'hole_x+': np.array([+1., 0.,0.]),
+                        'hole_y-': np.array([0., -1.,0.]),
+
+
+                           }
+boundaryTags = {'y-': 1,
+                    'x+': 2,
+                    'y+': 3,
+                    'x-': 4,
+                    'sponge': 5,
+                    'circle':6,
+                    'hole_x-':7,
+                    'hole_x+':8,
+                    'hole_y-':9,
+                       }
+
+
+
+
+if opts.hole_tank:
+
+    vertices=[[0.0, 0.24],#0
+              [x1,  0.24],#1
+              [0.3,  0.24],#2
+              [0.3,  0.0],#3
+              [1.3,  0.0],#4
+              [1.3,  0.24],#5
+              [1.4,  0.24],#6
+              [tank_dim[0],0.24],#7
+              [tank_dim[0],tank_dim[1]+0.16], #8
+              [1.4, tank_dim[1]+0.16], #9
+              [0.2, tank_dim[1]+0.16], #10
+              [0.0, tank_dim[1]+0.16], #11
+              ]
+
+    vertexFlags=np.array([1, 1, 1,
+                          9, 9,
+                          1, 1, 1,
+                          3, 3, 3, 3,
+                          ])
+    segments=[[0,1],
+              [1,2],
+
+              [2,3],
+              [3,4],
+              [4,5],
+
+              [5,6],
+              [6,7],
+
+              [7,8],
+
+              [8,9],
+              [9,10],
+              [10,11],
+
+              [11,0],
+
+              [1,10],
+              [6,9],
+             ]
+
+    segmentFlags=np.array([ 1, 1, 
+                            7, 9, 8,
+                            1, 1,
+                            2,
+                            3, 3, 3, 
+                            4,
+                            5, 5,
+                         ])
+
+
+regions = [ [ 0.90*x1 , 0.50*tank_dim[1] ],
+            [ 0.7 , 0.50*tank_dim[1] ],
+            [ 0.95*tank_dim[0] , 0.50*tank_dim[1] ] ]
+
+regionFlags=np.array([1, 2, 3])
+
+
+
+tank = st.CustomShape(domain, vertices=vertices, vertexFlags=vertexFlags,
+                      segments=segments, segmentFlags=segmentFlags,
+                      regions=regions, regionFlags=regionFlags,
+                      boundaryTags=boundaryTags, boundaryOrientations=boundaryOrientations)
+
+
+
+
+
+#############################################################################################################################################################################################################################################################################################################################################################################################
+# ----- BOUNDARY CONDITIONS ----- #
+#############################################################################################################################################################################################################################################################################################################################################################################################
+
+if opts.circle2D:
+    
+    for bc in circle.BC_list:
+        if opts.circleBC == 'FreeSlip':
+            bc.setFreeSlip()
+        if opts.circleBC == 'NoSlip':
+            bc.setNoSlip()
+
+tank.BC['y-'].setFreeSlip()
+
+################################## y+ ######################
+tank.BC['y+'].setFreeSlip()
+
+####################################### x- ########################
+tank.BC['x-'].setFreeSlip()
+if opts.current:
+
+    tank.BC['x-'].setUnsteadyTwoPhaseVelocityInlet(wave=steady_current, smoothing = 3*he, vert_axis=1)
+    
+    #tank.BC['x-'].setTwoPhaseVelocityInlet(U=[opts.inflow_vel,0,0], waterLevel = opts.waterLevel,
+
+    tank.BC['x-'].pInit_advective.setConstantBC(0.0)
+    #tank.BC['x-'].pInc_advective.setConstantBC(0.0) 
+    tank.BC['x-'].pInit_diffusive.setConstantBC(0.0)
+    tank.BC['x-'].pInc_diffusive.setConstantBC(0.0)
+    tank.BC['x-'].pInc_advective.uOfXT = lambda x,t: -opts.inflow_vel
+    tank.BC['x-'].p_advective.setConstantBC(0.0)
+
+
+#################################### x+ ###############################
+tank.BC['x+'].setFreeSlip()
+
+if opts.current:
+    
+    tank.BC['x+'].setHydrostaticPressureOutletWithDepth(seaLevel=opts.waterLevel, rhoUp=rho_1, rhoDown = rho_0, g=g, refLevel= tank_dim[1], smoothing = 3*he)
+    
+    #tank.BC['x+'].pInit_dirichlet.setConstantBC(0.0)
+    #tank.BC['x+'].u_dirichlet.setConstantBC(0.0)
+    #tank.BC['x+'].v_dirichlet.setConstantBC(0.0)
+    #tank.BC['x+'].p_dirichlet.setConstantBC(0.0)
+    tank.BC['x+'].u_dirichlet.uOfXT = None
+    tank.BC['x+'].v_dirichlet.uOfXT = None
+    tank.BC['x+'].u_advective.setConstantBC(0.0)
+    tank.BC['x+'].v_advective.setConstantBC(0.0)
+    tank.BC['x+'].u_diffusive.setConstantBC(0.0)
+    tank.BC['x+'].v_diffusive.setConstantBC(0.0)
+    tank.BC['x+'].pInc_dirichlet.setConstantBC(0.0) 
+
+
+tank.BC['hole_x+'].setFreeSlip()
+
+
+tank.BC['hole_x-'].setFreeSlip()
+
+
+tank.BC['hole_y-'].setFreeSlip()
+
+
+tank.BC['hole_y-'].vos_dirichlet.setConstantBC(opts.cSed)
+
+
+if opts.current:
+
+    if opts.GenZone == True:
+        omega=1.0 
+        tank.setAbsorptionZones(flags=1, epsFact_solid=float(0.2/2.), dragAlpha=10.*omega/nu_0,
+                            orientation=[1., 0.], center=(float(0.2/2.), 0., 0.),
+                            )
+
+    if opts.AbsZone == True:
+        omega= 1.0
+        tank.setAbsorptionZones(flags=3, epsFact_solid=float(0.2/2.), dragAlpha=10.*omega/nu_0,
+                            orientation=[-1., 0.], center=(float(tank_dim[0]-0.2/2.), 0., 0.),
+                            )
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Turbulence
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+
+if opts.useRANS:
+    kInflow = 1e-6
+    dissipationInflow = 1e-6
+    tank.BC['x-'].setTurbulentZeroGradient()
+    tank.BC['x+'].setTurbulentZeroGradient()
+    tank.BC['y-'].setTurbulentZeroGradient()
+    tank.BC['y+'].setTurbulentZeroGradient()
+
+
+######################################################################################################################################################################################################################
+# Gauges and probes #
+######################################################################################################################################################################################################################
+
+T=opts.duration
+PG = []
+gauge_dy=0.01
+tank_dim_y=tank_dim[1]
+nprobes=int(tank_dim_y/gauge_dy)+1
+probes=np.linspace(0., tank_dim_y, nprobes)
+for i in probes:
+    PG.append((tank_dim[0]/2., i, 0.),)
+v_output = ga.PointGauges(gauges=((('u',), PG),
+                                  (('v',), PG),),
+                          activeTime = (0., T),
+                          sampleRate=0.,
+                          fileName='fluidVelocityGauges.csv')
+vs_output = ga.PointGauges(gauges=((('us',),PG), 
+                                   (('vs',),PG),),
+                          activeTime = (0., T),
+                          sampleRate=0.,
+                          fileName='solidVelocityGauges.csv')
+vos_output = ga.PointGauges(gauges=((('vos',),PG),),
+                          activeTime = (0., T),
+                          sampleRate=0.,
+                          fileName='solidFractionGauges.csv')
+
+
+######################################################################################################################################################################################################################
+# Numerical Options and other parameters #
+######################################################################################################################################################################################################################
+ 
+domain.MeshOptions.he = he
+
+from math import *
+from proteus import MeshTools, AuxiliaryVariables
+import numpy
+import proteus.MeshTools
+from proteus import Domain
+from proteus.Profiling import logEvent
+from proteus.default_n import *
+from proteus.ctransportCoefficients import smoothedHeaviside
+from proteus.ctransportCoefficients import smoothedHeaviside_integral
+
+st.assembleDomain(domain)
+
+
+#----------------------------------------------------
+# Time stepping and velocity
+#----------------------------------------------------
+
+T=opts.duration
+weak_bc_penalty_constant = 10.0/nu_0 #100
+dt_fixed = opts.dtout
+dt_init = min(0.1*dt_fixed,0.001)
+nDTout= int(round(T/dt_fixed))
+runCFL = opts.cfl
+
+sedimentDynamics=opts.sedimentDynamics
+
+#----------------------------------------------------
+#  Discretization -- input options
+#----------------------------------------------------
+
+genMesh = True
+movingDomain = False
+applyRedistancing = True
+useOldPETSc = False
+useSuperlu = False
+timeDiscretization = 'be'#'vbdf'#'vbdf'  # 'vbdf', 'be', 'flcbdf'
+spaceOrder = 1
+pspaceOrder = 1
+useHex = False
+useRBLES = 0.0
+useMetrics = 1.0
+applyCorrection = True
+useVF = 1.0
+useOnlyVF = False
+useRANS = opts.useRANS  # 0 -- None
+                        # 1 -- K-Epsilon
+                        # 2 -- K-Omega
+
+
+KILL_PRESSURE_TERM = False
+fixNullSpace_PresInc = True
+INTEGRATE_BY_PARTS_DIV_U_PresInc = True
+CORRECT_VELOCITY = True
+STABILIZATION_TYPE = 0 #0: SUPG, 1: EV via weak residual, 2: EV via strong residual
+
+# Input checks
+if spaceOrder not in [1, 2]:
+    print "INVALID: spaceOrder" + spaceOrder
+    sys.exit()
+
+if useRBLES not in [0.0, 1.0]:
+    print "INVALID: useRBLES" + useRBLES
+    sys.exit()
+
+if useMetrics not in [0.0, 1.0]:
+    print "INVALID: useMetrics"
+    sys.exit()
+
+#  Discretization
+nd = tank.nd
+
+if spaceOrder == 1:
+    hFactor = 1.0
+    if useHex:
+        basis = C0_AffineLinearOnCubeWithNodalBasis
+        elementQuadrature = CubeGaussQuadrature(nd, 2)
+        elementBoundaryQuadrature = CubeGaussQuadrature(nd - 1, 2)
+    else:
+        basis = C0_AffineLinearOnSimplexWithNodalBasis
+        elementQuadrature = SimplexGaussQuadrature(nd, 3)
+        elementBoundaryQuadrature = SimplexGaussQuadrature(nd - 1, 3)
+elif spaceOrder == 2:
+    hFactor = 0.5
+    if useHex:
+        basis = C0_AffineLagrangeOnCubeWithNodalBasis
+        elementQuadrature = CubeGaussQuadrature(nd, 4)
+        elementBoundaryQuadrature = CubeGaussQuadrature(nd - 1, 4)
+    else:
+        basis = C0_AffineQuadraticOnSimplexWithNodalBasis
+        elementQuadrature = SimplexGaussQuadrature(nd, 4)
+        elementBoundaryQuadrature = SimplexGaussQuadrature(nd - 1, 4)
+
+if pspaceOrder == 1:
+    if useHex:
+        pbasis = C0_AffineLinearOnCubeWithNodalBasis
+    else:
+        pbasis = C0_AffineLinearOnSimplexWithNodalBasis
+elif pspaceOrder == 2:
+    if useHex:
+        pbasis = C0_AffineLagrangeOnCubeWithNodalBasis
+    else:
+        pbasis = C0_AffineQuadraticOnSimplexWithNodalBasis
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Numerical parameters
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+ns_forceStrongDirichlet = False
+ns_sed_forceStrongDirichlet = False
+backgroundDiffusionFactor=0.01
+
+if useMetrics:
+    ns_shockCapturingFactor = 0.5
+    ns_lag_shockCapturing = True
+    ns_lag_subgridError = True
+    ns_sed_shockCapturingFactor = 0.5
+    ns_sed_lag_shockCapturing = True
+    ns_sed_lag_subgridError = True
+    ls_shockCapturingFactor = 0.5
+    ls_lag_shockCapturing = True
+    ls_sc_uref = 1.0
+    ls_sc_beta = 1.0
+    vof_shockCapturingFactor = 0.5
+    vof_lag_shockCapturing = True
+    vof_sc_uref = 1.0
+    vof_sc_beta = 1.0
+    vos_shockCapturingFactor = opts.vos_SC # <------------------------------------- 
+    vos_lag_shockCapturing = True
+    vos_sc_uref = 1.0
+    vos_sc_beta = 1.0
+    rd_shockCapturingFactor = 0.5
+    rd_lag_shockCapturing = False
+    epsFact_vos =opts.epsFact_density
+    epsFact_density = opts.epsFact_density # 1.5
+    epsFact_viscosity = epsFact_curvature = epsFact_vof = epsFact_consrv_heaviside = epsFact_consrv_dirac = epsFact_density
+    epsFact_redistance = 0.33
+    epsFact_consrv_diffusion = opts.epsFact_consrv_diffusion # 0.1
+    redist_Newton = True
+    kappa_shockCapturingFactor = 0.25
+    kappa_lag_shockCapturing = True  #False
+    kappa_sc_uref = 1.0
+    kappa_sc_beta = 1.0
+    dissipation_shockCapturingFactor = 0.25
+    dissipation_lag_shockCapturing = True  #False
+    dissipation_sc_uref = 1.0
+    dissipation_sc_beta = 1.0
+else:
+    ns_shockCapturingFactor = 0.9
+    ns_lag_shockCapturing = True
+    ns_lag_subgridError = True
+    ns_sed_shockCapturingFactor = 0.9
+    ns_sed_lag_shockCapturing = True
+    ns_sed_lag_subgridError = True
+    ls_shockCapturingFactor = 0.9
+    ls_lag_shockCapturing = True
+    ls_sc_uref = 1.0
+    ls_sc_beta = 1.0
+    vof_shockCapturingFactor = 0.9
+    vof_lag_shockCapturing = True
+    vof_sc_uref = 1.0
+    vof_sc_beta = 1.0
+    vos_shockCapturingFactor = 2.
+    vos_lag_shockCapturing = True
+    vos_sc_uref = 1.0
+    vos_sc_beta = 1.0
+    rd_shockCapturingFactor = 0.9
+    rd_lag_shockCapturing = False
+    epsFact_density = opts.epsFact_density # 1.5
+    epsFact_viscosity = epsFact_curvature = epsFact_vof = epsFact_vos = epsFact_consrv_heaviside = epsFact_consrv_dirac = epsFact_density
+    epsFact_redistance = 0.33
+    epsFact_consrv_diffusion = opts.epsFact_consrv_diffusion # 1.0
+    redist_Newton = False
+    kappa_shockCapturingFactor = 0.9
+    kappa_lag_shockCapturing = True  #False
+    kappa_sc_uref = 1.0
+    kappa_sc_beta = 1.0
+    dissipation_shockCapturingFactor = 0.9
+    dissipation_lag_shockCapturing = True  #False
+    dissipation_sc_uref = 1.0
+    dissipation_sc_beta = 1.0
+
+ns_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+ns_sed_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+vof_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+vos_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+ls_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+rd_nl_atol_res =  max(opts.res, 0.005 * he)
+mcorr_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+kappa_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+dissipation_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+phi_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+pressure_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Turbulence
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+ns_closure = 0  #1-classic smagorinsky, 2-dynamic smagorinsky, 3 -- k-epsilon, 4 -- k-omega
+ns_sed_closure = 0  #1-classic smagorinsky, 2-dynamic smagorinsky, 3 -- k-epsilon, 4 -- k-omega
+if useRANS == 1:
+    ns_closure = 3
+elif useRANS == 2:
+    ns_closure == 4
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Functions for model variables - Initial conditions
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+waterLine_z = opts.waterLevel
+
+def signedDistance(x):
+    phi_z = x[1] - waterLine_z
+    return phi_z
+
+def vos_signedDistance(x):
+    phi_z = x[1] - 0.75*waterLine_z
+    return phi_z
+
+class Suspension_class:
+    def __init__(self):
+        pass
+    def uOfXT(self, x, t=0):
+        phi = signedDistance(x) + 0.29   # 0.6 is the distance between the free surface and the sediments
+        smoothing = (epsFact_consrv_heaviside)*he/2.
+        Heav = smoothedHeaviside(smoothing, phi)      
+        if phi <= -smoothing:
+            return opts.cSed
+        elif -smoothing < phi < smoothing:
+            return opts.cSed * (1.-Heav)            
+        else:
+            return 1e-10    
+
+def vos_function(x, t=0):
+    phi = signedDistance(x) + 0.29
+    smoothing = (epsFact_consrv_heaviside)*he/2.
+    Heav = smoothedHeaviside(smoothing, phi)      
+    if phi <= -smoothing:
+        return opts.cSed
+    elif -smoothing < phi < smoothing:
+        return opts.cSed * (1.-Heav)            
+    else:
+        return 1e-10    
+
+
+Suspension = Suspension_class()
+

--- a/2d/sediment/pipe_scour/tank_so.py
+++ b/2d/sediment/pipe_scour/tank_so.py
@@ -1,0 +1,83 @@
+from proteus import StepControl
+"""
+Split operator module for two-phase flow
+"""
+
+from proteus.default_so import *
+import os
+from proteus import Context
+
+# Create context from main module
+name_so = os.path.basename(__file__)
+if '_so.py' in name_so[-6:]:
+    name = name_so[:-6]
+elif '_so.pyc' in name_so[-7:]:
+    name = name_so[:-7]
+else:
+    raise NameError, 'Split operator module must end with "_so.py"'
+
+try:
+    case = __import__(name)
+    Context.setFromModule(case)
+    ct = Context.get()
+except ImportError:
+    raise ImportError, str(name) + '.py not found'
+
+from proteus import BoundaryConditions
+for BC in ct.domain.bc:
+    BC.getContext()
+
+from proteus.SplitOperator import Sequential_FixedStep_Simple, defaultSystem
+if ct.sedimentDynamics:
+    PINIT_model=9
+    pnList = [("vos_p",               "vos_n"),#0
+              ("vof_p",               "vof_n"),#1
+              ("ls_p",                "ls_n"),#2
+              ("redist_p",            "redist_n"),#3
+              ("ls_consrv_p",         "ls_consrv_n"),#4
+              ("threep_navier_stokes_sed_p", "threep_navier_stokes_sed_n"),#5
+              ("twp_navier_stokes_p", "twp_navier_stokes_n"),#6
+              ("pressureincrement_p", "pressureincrement_n"),#7
+              ("pressure_p", "pressure_n"),#8
+              ("pressureInitial_p", "pressureInitial_n")]#9
+else:
+    PINIT_model=7
+    pnList = [("vof_p",               "vof_n"),#0
+              ("ls_p",                "ls_n"),#1
+              ("redist_p",            "redist_n"),#2
+              ("ls_consrv_p",         "ls_consrv_n"),#3
+              ("twp_navier_stokes_p", "twp_navier_stokes_n"),#4
+              ("pressureincrement_p", "pressureincrement_n"),#5
+              ("pressure_p", "pressure_n"),#6
+              ("pressureInitial_p", "pressureInitial_n")]#7
+
+if ct.useRANS > 0:
+    pnList.append(("kappa_p",
+                   "kappa_n"))
+    pnList.append(("dissipation_p",
+                   "dissipation_n"))
+name = "tank"
+
+#modelSpinUpList = [ct.VOF_model, ct.LS_model, ct.V_model, ct.PINIT_model]
+modelSpinUpList = [PINIT_model]
+
+class Sequential_MinAdaptiveModelStepPS(Sequential_MinAdaptiveModelStep):
+    def __init__(self,modelList,system=defaultSystem,stepExact=True):
+        Sequential_MinAdaptiveModelStep.__init__(self,modelList,system,stepExact)
+        self.modelList = modelList[:len(pnList)-1]
+
+#class Sequential_MinAdaptiveModelStepPS(Sequential_FixedStep):
+#    def __init__(self,modelList,system=defaultSystem,stepExact=True):
+#        Sequential_FixedStep.__init__(self,modelList,system,stepExact)
+#        self.modelList = modelList[:len(pnList)-1]
+#dt_system_fixed = ct.dt_fixed
+
+systemStepControllerType = Sequential_MinAdaptiveModelStepPS
+
+needEBQ_GLOBAL = False
+needEBQ = False
+
+tnList = [0.0,ct.dt_init]+[ct.dt_init+i*ct.dt_fixed for i in range(1,ct.nDTout+1)]
+
+info = open("TimeList.txt","w")
+#archiveFlag = ArchiveFlags.EVERY_SEQUENCE_STEP

--- a/2d/sediment/pipe_scour/threep_navier_stokes_sed_n.py
+++ b/2d/sediment/pipe_scour/threep_navier_stokes_sed_n.py
@@ -1,0 +1,72 @@
+from proteus import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+from threep_navier_stokes_sed_p import *
+from tank import *
+
+if timeDiscretization=='vbdf':
+    timeIntegration = VBDF
+    timeOrder=2
+    stepController  = Min_dt_cfl_controller
+elif timeDiscretization=='flcbdf':
+    timeIntegration = FLCBDF
+    #stepController = FLCBDF_controller_sys
+    stepController  = Min_dt_cfl_controller
+    time_tol = 10.0*ns_sed_nl_atol_res
+    atol_u = {0:time_tol,1:time_tol}
+    rtol_u = {0:time_tol,1:time_tol}
+else:
+    timeIntegration = BackwardEuler_cfl
+    stepController  = Min_dt_cfl_controller
+
+femSpaces = {0:basis,
+	     1:basis}
+
+massLumping       = False
+numericalFluxType = None
+conservativeFlux  = None
+
+numericalFluxType = RANS3PSed.NumericalFlux
+subgridError = RANS3PSed.SubgridError(coefficients,nd,lag=ns_sed_lag_subgridError,hFactor=hFactor)
+shockCapturing = RANS3PSed.ShockCapturing(coefficients,nd,ns_sed_shockCapturingFactor,lag=ns_sed_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+
+linearSmoother    = None
+
+matrix = SparseMatrix
+
+if useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'rans3p_sed_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest             = 'r-true'
+
+tolFac = 0.0
+linTolFac = 0.01
+l_atol_res = 0.01*ns_sed_nl_atol_res
+nl_atol_res = ns_sed_nl_atol_res
+useEisenstatWalker = False
+maxNonlinearIts = 50
+maxLineSearches = 0
+conservativeFlux = {0:'point-eval'}
+#conservativeFlux = {0:'pwl-bdm-opt'}
+#auxiliaryVariables=[pointGauges,lineGauges]
+auxiliaryVariables = ct.domain.auxiliaryVariables['thp']+[ct.vs_output]

--- a/2d/sediment/pipe_scour/threep_navier_stokes_sed_p.py
+++ b/2d/sediment/pipe_scour/threep_navier_stokes_sed_p.py
@@ -1,0 +1,118 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import RANS3PSed
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = RANS3PSed.LevelModel
+
+if ct.sedimentDynamics:
+    VOS_model=0
+    VOF_model=1
+    LS_model=2
+    RD_model=3
+    MCORR_model=4
+    SED_model=5
+    V_model=6
+    PINC_model=7
+    PRESSURE_model=8
+    PINIT_model=9
+else:
+    VOS_model=None
+    SED_model=None
+    VOF_model=0
+    LS_model=1
+    RD_model=2
+    MCORR_model=3
+    V_model=4
+    PINC_model=5
+    PRESSURE_model=6
+    PINIT_model=7
+
+if useOnlyVF:
+    LS_model = None
+else:
+    LS_model = 2
+if useRANS >= 1:
+    Closure_0_model = 5; Closure_1_model=6
+    if useOnlyVF:
+        Closure_0_model=2; Closure_1_model=3
+    if movingDomain:
+        Closure_0_model += 1; Closure_1_model += 1
+else:
+    Closure_0_model = None
+    Closure_1_model = None
+
+coefficients = RANS3PSed.Coefficients(epsFact=epsFact_viscosity,
+                                      sigma=0.0,
+                                      rho_0 = rho_0,
+                                      nu_0 = nu_0, 
+                                      rho_1 = rho_1,
+                                      nu_1 = nu_1,
+                                      rho_s = rho_s,
+                                      g=g,
+                                      nd=nd,
+                                      ME_model=SED_model,
+                                      PRESSURE_model=PRESSURE_model,
+                                      FLUID_model=V_model,
+                                      VOS_model=VOS_model,
+                                      VOF_model=VOF_model,
+                                      LS_model=LS_model,
+                                      Closure_0_model=Closure_0_model,
+                                      Closure_1_model=Closure_1_model,
+                                      epsFact_density=epsFact_density,
+                                      stokes=False,
+                                      useVF=True,
+                                      useRBLES=useRBLES,
+                                      useMetrics=useMetrics,
+                                      eb_adjoint_sigma=1.0,
+                                      eb_penalty_constant=weak_bc_penalty_constant,
+                                      forceStrongDirichlet=ns_forceStrongDirichlet,
+                                      turbulenceClosureModel=ns_closure,
+                                      movingDomain=movingDomain,
+                                      dragAlpha=dragAlpha,
+                                      PSTAB=ct.opts.PSTAB,
+                                    aDarcy = sedClosure.aDarcy,
+                                    betaForch = sedClosure.betaForch,
+                                    grain = sedClosure.grain,
+                                    packFraction = sedClosure.packFraction,
+                                    maxFraction = sedClosure.maxFraction,
+                                    frFraction = sedClosure.frFraction,
+                                    sigmaC = sedClosure.sigmaC,
+                                    C3e = sedClosure.C3e,
+                                    C4e = sedClosure.C4e,
+                                    eR = sedClosure.eR,
+                                    fContact = sedClosure.fContact,
+                                    mContact = sedClosure.mContact,
+                                    nContact = sedClosure.nContact,
+                                    angFriction = sedClosure.angFriction,
+                                    vos_function = ct.vos_function,
+                                    staticSediment = False,
+                                    vos_limiter = ct.sedClosure.vos_limiter,
+                                    mu_fr_limiter = ct.sedClosure.mu_fr_limiter,
+                                    )
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].us_dirichlet.init_cython(),
+                       1: lambda x, flag: domain.bc[flag].vs_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].us_advective.init_cython(),
+                                   1: lambda x, flag: domain.bc[flag].vs_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {0: lambda x, flag: domain.bc[flag].us_diffusive.init_cython()},
+                                   1: {1: lambda x, flag: domain.bc[flag].vs_diffusive.init_cython()}}
+
+if nd == 3:
+    dirichletConditions[2] = lambda x, flag: domain.bc[flag].ws_dirichlet.init_cython()
+    advectiveFluxBoundaryConditions[2] = lambda x, flag: domain.bc[flag].ws_advective.init_cython()
+    diffusiveFluxBoundaryConditions[2] = {2: lambda x, flag: domain.bc[flag].ws_diffusive.init_cython()}
+
+class AtRest:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+initialConditions = {0:AtRest(),
+                     1:AtRest()}

--- a/2d/sediment/pipe_scour/twp_navier_stokes_n.py
+++ b/2d/sediment/pipe_scour/twp_navier_stokes_n.py
@@ -1,0 +1,74 @@
+from proteus import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+from twp_navier_stokes_p import *
+from tank import *
+
+if timeDiscretization=='vbdf':
+    timeIntegration = VBDF
+    timeOrder=2
+    stepController  = Min_dt_cfl_controller
+elif timeDiscretization=='flcbdf':
+    timeIntegration = FLCBDF
+    #stepController = FLCBDF_controller_sys
+    stepController  = Min_dt_cfl_controller
+    time_tol = 10.0*ns_nl_atol_res
+    atol_u = {0:time_tol,1:time_tol}
+    rtol_u = {0:time_tol,1:time_tol}
+else:
+    timeIntegration = BackwardEuler_cfl
+    stepController  = Min_dt_cfl_controller
+
+femSpaces = {0:basis,
+	     1:basis}
+#femSpaces = {0:C0_AffineQuadraticOnSimplexWithNodalBasis,
+#             1:C0_AffineQuadraticOnSimplexWithNodalBasis}
+
+massLumping       = False
+numericalFluxType = None
+conservativeFlux  = None
+
+numericalFluxType = RANS3PF.NumericalFlux
+subgridError = RANS3PF.SubgridError(coefficients,nd,lag=ns_lag_subgridError,hFactor=hFactor)
+shockCapturing = RANS3PF.ShockCapturing(coefficients,nd,ns_shockCapturingFactor,lag=ns_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+
+linearSmoother    = None #SimpleNavierStokes2D
+
+matrix = SparseMatrix
+
+if useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'rans2p_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest             = 'r-true'
+
+tolFac = 0.0
+linTolFac = 0.01
+l_atol_res = 0.01*ns_nl_atol_res
+nl_atol_res = ns_nl_atol_res
+useEisenstatWalker = False
+maxNonlinearIts = 50
+maxLineSearches = 0
+conservativeFlux = {0:'point-eval'}
+#conservativeFlux = {0:'pwl-bdm-opt'}
+#auxiliaryVariables=[pointGauges,lineGauges]
+auxiliaryVariables = ct.domain.auxiliaryVariables['twp']+[ct.v_output]

--- a/2d/sediment/pipe_scour/twp_navier_stokes_p.py
+++ b/2d/sediment/pipe_scour/twp_navier_stokes_p.py
@@ -1,0 +1,165 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import RANS3PF
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = RANS3PF.LevelModel
+
+if ct.sedimentDynamics:
+    VOS_model=0
+    VOF_model=1
+    LS_model=2
+    RD_model=3
+    MCORR_model=4
+    SED_model=5
+    V_model=6
+    PINC_model=7
+    PRESSURE_model=8
+    PINIT_model=9
+else:
+    VOS_model=None
+    SED_model=None
+    VOF_model=0
+    LS_model=1
+    RD_model=2
+    MCORR_model=3
+    V_model=4
+    PINC_model=5
+    PRESSURE_model=6
+    PINIT_model=7
+if useOnlyVF:
+    LS_model = None
+else:
+    LS_model = 2
+if useRANS >= 1:
+    Closure_0_model = 5; Closure_1_model=6
+    if useOnlyVF:
+        Closure_0_model=2; Closure_1_model=3
+    if movingDomain:
+        Closure_0_model += 1; Closure_1_model += 1
+else:
+    Closure_0_model = None
+    Closure_1_model = None
+
+coefficients = RANS3PF.Coefficients(epsFact=epsFact_viscosity,
+                                    sigma=0.0,
+                                    rho_0 = rho_0,
+                                    nu_0 = nu_0,
+                                    rho_1 = rho_1,
+                                    nu_1 = nu_1,
+                                    g=g,
+                                    nd=nd,
+                                    ME_model=V_model,
+                                    PRESSURE_model=PRESSURE_model,
+                                    SED_model=SED_model,
+                                    VOF_model=VOF_model,
+                                    VOS_model=VOS_model,
+                                    LS_model=LS_model,
+                                    Closure_0_model=Closure_0_model,
+                                    Closure_1_model=Closure_1_model,
+                                    epsFact_density=epsFact_density,
+                                    stokes=False,
+                                    useVF=useVF,
+                                    useRBLES=useRBLES,
+                                    useMetrics=useMetrics,
+                                    eb_adjoint_sigma=1.0,
+                                    eb_penalty_constant=weak_bc_penalty_constant,
+                                    forceStrongDirichlet=ns_forceStrongDirichlet,
+                                    turbulenceClosureModel=ns_closure,
+                                    movingDomain=movingDomain,
+                                    dragAlpha=dragAlpha,
+                                    PSTAB=ct.opts.PSTAB,
+                                    aDarcy = sedClosure.aDarcy,
+                                    betaForch = sedClosure.betaForch,
+                                    grain = sedClosure.grain,
+                                    packFraction = sedClosure.packFraction,
+                                    maxFraction = sedClosure.maxFraction,
+                                    frFraction = sedClosure.frFraction,
+                                    sigmaC = sedClosure.sigmaC,
+                                    C3e = sedClosure.C3e,
+                                    C4e = sedClosure.C4e,
+                                    eR = sedClosure.eR,
+                                    fContact = sedClosure.fContact,
+                                    mContact = sedClosure.mContact,
+                                    nContact = sedClosure.nContact,
+                                    angFriction = sedClosure.angFriction,
+                                    vos_function = ct.vos_function,
+                                    vos_limiter = ct.sedClosure.vos_limiter,
+                                    mu_fr_limiter = ct.sedClosure.mu_fr_limiter,
+                                    )
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].u_dirichlet.init_cython(),
+                       1: lambda x, flag: domain.bc[flag].v_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].u_advective.init_cython(),
+                                   1: lambda x, flag: domain.bc[flag].v_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {0: lambda x, flag: domain.bc[flag].u_diffusive.init_cython()},
+                                   1: {1: lambda x, flag: domain.bc[flag].v_diffusive.init_cython()}}
+
+if nd == 3:
+    dirichletConditions[2] = lambda x, flag: domain.bc[flag].w_dirichlet.init_cython()
+    advectiveFluxBoundaryConditions[2] = lambda x, flag: domain.bc[flag].w_advective.init_cython()
+    diffusiveFluxBoundaryConditions[2] = {2: lambda x, flag: domain.bc[flag].w_diffusive.init_cython()}
+
+class AtRest:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+
+smoothing = 3*he
+
+
+class U_IC:
+
+
+    def uOfXT(self,x,t):
+        if ct.signedDistance(x) <= -0.28:
+            H = 1
+            speed = 0
+        elif -0.278 < ct.signedDistance(x) < -0.28 + smoothing:
+            H = 1-(smoothedHeaviside(smoothing/2. , ct.signedDistance(x)+0.28 - smoothing/2.))
+            speed = ct.opts.inflow_vel
+
+        elif  (ct.signedDistance(x) <= 0): 
+        #and ct.signedDistance(x)>= -0.27+smoothing):
+            H = 0
+            speed = ct.opts.inflow_vel
+        
+        elif 0 < ct.signedDistance(x) <= smoothing:
+            H = smoothedHeaviside(smoothing/2. , ct.signedDistance(x) - smoothing/2.)
+            speed = ct.opts.inflow_vel
+        else:
+            H = 1
+            speed = 0
+        
+        u = H * 0.0 + (1-H)*speed
+
+        return u
+
+
+class V_IC:
+    def uOfXT(self,x,t):
+                
+        v = 0.0
+
+        return v
+
+
+
+
+#if ct.opts.current:
+#    initialConditions = {0: U_IC(),
+#                         1: V_IC()}
+#
+#else:    
+#    initialConditions = {0:AtRest(),
+#                         1:AtRest()}
+
+initialConditions = {0:AtRest(),
+                     1:AtRest()}

--- a/2d/sediment/pipe_scour/vof_n.py
+++ b/2d/sediment/pipe_scour/vof_n.py
@@ -1,0 +1,77 @@
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import vof_p as physics
+from proteus.mprans import VOF3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+# time stepping
+runCFL = ct.runCFL
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_controller
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = VOF3P.NumericalFlux
+conservativeFlux  = None
+subgridError      = VOF3P.SubgridError(coefficients=physics.coefficients,nd=nd)
+shockCapturing    = VOF3P.ShockCapturing(physics.coefficients,nd,shockCapturingFactor=ct.vof_shockCapturingFactor,lag=ct.vof_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'vof_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'r-true'
+
+tolFac      = 0.0
+nl_atol_res = ct.vof_nl_atol_res
+
+linTolFac   = 0.0
+l_atol_res = 0.1*ct.vof_nl_atol_res
+
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+
+auxiliaryVariables = ct.domain.auxiliaryVariables['vof']

--- a/2d/sediment/pipe_scour/vof_p.py
+++ b/2d/sediment/pipe_scour/vof_p.py
@@ -1,0 +1,52 @@
+from proteus.default_p import *
+from proteus.ctransportCoefficients import smoothedHeaviside
+from proteus.mprans import VOF3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+LevelModelType = VOF3P.LevelModel
+
+if ct.sedimentDynamics:
+    LS_model=2
+    V_model=6
+    RD_model=3
+    VOF_model=1
+    VOS_model=0
+else:
+    VOS_model=None
+    VOF_model=0
+    LS_model=1
+    RD_model=2
+    V_model=4
+
+coefficients = VOF3P.Coefficients(LS_model=LS_model,
+                                  V_model=V_model,
+                                  RD_model=RD_model,
+                                  ME_model=VOF_model,
+                                  VOS_model=VOS_model,
+                                  checkMass=True,
+                                  useMetrics=ct.useMetrics,
+                                  epsFact=ct.epsFact_vof,
+                                  sc_uref=ct.vof_sc_uref,
+                                  sc_beta=ct.vof_sc_beta,
+                                  movingDomain=ct.movingDomain)
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].vof_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].vof_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {}}
+
+class VF_IC:
+    def uOfXT(self, x, t):
+        return smoothedHeaviside(ct.epsFact_consrv_heaviside*mesh.he,x[nd-1]-ct.waterLevel)
+
+initialConditions = {0: VF_IC()}

--- a/2d/sediment/pipe_scour/vos_n.py
+++ b/2d/sediment/pipe_scour/vos_n.py
@@ -1,0 +1,81 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import vof_p as physics
+from proteus import Context
+from proteus.mprans import VOS3P
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+# time stepping
+runCFL = ct.runCFL
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_controller
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = VOS3P.NumericalFlux
+conservativeFlux  = None
+subgridError      = VOS3P.SubgridError(coefficients=physics.coefficients,nd=nd)
+shockCapturing    = VOS3P.ShockCapturing(physics.coefficients,nd,shockCapturingFactor=ct.vos_shockCapturingFactor,lag=ct.vos_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'vos_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'r-true'
+
+tolFac      = 0.0
+nl_atol_res = ct.vos_nl_atol_res
+
+linTolFac   = 0.0
+l_atol_res = 0.1*ct.vos_nl_atol_res
+
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+
+#auxiliaryVariables = ct.domain.auxiliaryVariables['vos']
+auxiliaryVariables = ct.domain.auxiliaryVariables['vos']+[ct.vos_output]

--- a/2d/sediment/pipe_scour/vos_p.py
+++ b/2d/sediment/pipe_scour/vos_p.py
@@ -1,0 +1,44 @@
+from proteus import StepControl
+from proteus.default_p import *
+from proteus.ctransportCoefficients import smoothedHeaviside
+from proteus.mprans import VOS3P
+from proteus import Context
+from proteus import *
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+LevelModelType = VOS3P.LevelModel
+
+
+if ct.sedimentDynamics:
+    V_model=6
+    SED_model=5
+else:
+    V_model=4
+    SED_model=None
+
+coefficients = VOS3P.Coefficients(LS_model=None,
+                                  V_model=V_model,
+                                  SED_model=SED_model,
+                                  RD_model=None,
+                                  ME_model=0,
+                                  checkMass=False,
+                                  useMetrics=ct.useMetrics,
+                                  epsFact=ct.epsFact_vos,
+                                  sc_uref=ct.vos_sc_uref,
+                                  sc_beta=ct.vos_sc_beta,
+                                  movingDomain=ct.movingDomain,
+                                  vos_function=ct.vos_function,
+                                  )
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].vos_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].vos_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {}}
+
+
+initialConditions  = {0:ct.Suspension}

--- a/2d/sediment/sediment_erosion/TimeSeriesPlot.py
+++ b/2d/sediment/sediment_erosion/TimeSeriesPlot.py
@@ -1,0 +1,54 @@
+from proteus import StepControl
+#from scipy import *
+from pylab import *
+from numpy import *
+import collections as cll
+
+filename='pointGauge_pressure.txt'
+headerline = 0
+
+
+# Read header info 
+
+fid = open(filename,'r')
+prdata=loadtxt(fid,skiprows=headerline)
+fid.seek(0)
+D = fid.readlines()
+header = D[:headerline]
+n=len(D)
+
+a = array(zeros((int(n),5)))
+step = zeros(int(n),float)
+for i in range (int(n)):
+ a[i,:]=D[i].split()
+ step[i]=i
+
+a = array(a,dtype=float32)
+
+y = zeros(int(n),float)
+
+y[:] = a[:,2]
+
+
+
+
+
+
+#j=str(2)
+
+fig1 = figure(1)
+fig1.add_subplot(1,1,1)
+plot(step[:],y[:],"k",lw=2)
+
+##xlim(80,90)
+##ylim(-0.05,0.05)
+
+grid()
+#title('Surface elevation at $x=$' + str(probex[int(j)])+'m')
+title('Point gauge pressure evolution')
+xlabel('Step')
+ylabel('Pressure')
+
+show()
+savefig('plottrial.pdf')
+savefig('plottrial.png',dpi=100)

--- a/2d/sediment/sediment_erosion/dissipation_n.py
+++ b/2d/sediment/sediment_erosion/dissipation_n.py
@@ -1,0 +1,59 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import dissipation_p as physics
+from proteus import Context
+from proteus.mprans import Dissipation
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+triangleOptions = mesh.triangleOptions
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_cfl_controller
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = Dissipation.NumericalFlux
+conservativeFlux  = None
+subgridError      = Dissipation.SubgridError(coefficients=physics.coefficients,nd=ct.nd)
+shockCapturing    = Dissipation.ShockCapturing(physics.coefficients,ct.nd,shockCapturingFactor=ct.dissipation_shockCapturingFactor,
+                                         lag=ct.dissipation_lag_shockCapturing)
+
+fullNewtonFlag  = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+#printNonlinearSolverInfo = True
+matrix = SparseMatrix
+if not ct.useOldPETSc and not ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+else:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'dissipation_'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'rits'
+
+tolFac = 0.0
+linTolFac =0.0
+l_atol_res = 0.001*ct.dissipation_nl_atol_res
+nl_atol_res = ct.dissipation_nl_atol_res
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+

--- a/2d/sediment/sediment_erosion/dissipation_p.py
+++ b/2d/sediment/sediment_erosion/dissipation_p.py
@@ -1,0 +1,53 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import Dissipation
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = Dissipation.LevelModel
+
+dissipation_model_flag = 1
+if ct.useRANS >= 2:
+    dissipation_model_flag=2
+coefficients = Dissipation.Coefficients(V_model=ct.V_model,
+                                        ME_model=ct.EPS_model,
+                                        LS_model=ct.LS_model,
+                                        RD_model=ct.RD_model,
+                                        kappa_model=ct.K_model,
+                                        SED_model=ct.SED_model,
+                                        dissipation_model_flag=dissipation_model_flag+int(ct.movingDomain),#1 -- K-epsilon, 2 -- K-omega
+                                        useMetrics=useMetrics,
+                                        rho_0=rho_0,
+                                        nu_0=nu_0,
+                                        rho_1=rho_1,
+                                        nu_1=nu_1,
+                                        g=g,
+                                        c_mu=ct.opts.Cmu,sigma_e=ct.opts.sigma_e,
+                                        nd = ct.nd,
+                                        sc_uref=dissipation_sc_uref,
+                                        sc_beta=dissipation_sc_beta,
+                                        closure = ct.sedClosure )
+
+kInflow=ct.kInflow
+
+dissipationInflow=ct.dissipationInflow
+
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].dissipation_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].dissipation_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {},
+                                   1: {1: lambda x, flag: domain.bc[flag].dissipation_diffusive.init_cython()},
+                                  }
+
+ 
+class ConstantIC:
+    def __init__(self,cval=0.0):
+        self.cval=cval
+    def uOfXT(self,x,t):
+        return self.cval
+
+initialConditions  = {0:ConstantIC(cval=dissipationInflow)}

--- a/2d/sediment/sediment_erosion/eddy_viscosity_view_batch.py
+++ b/2d/sediment/sediment_erosion/eddy_viscosity_view_batch.py
@@ -1,0 +1,7 @@
+from proteus import StepControl
+#0 is Navier-Stokes flow model
+simFlagsList[0]['storeQuantities']= ['simulationData',"q:'eddy_viscosity'"]
+simFlagsList[0]['storeTimes']     = ['All']
+#
+start
+quit

--- a/2d/sediment/sediment_erosion/kappa_n.py
+++ b/2d/sediment/sediment_erosion/kappa_n.py
@@ -1,0 +1,61 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import kappa_p as physics
+from proteus import Context
+from proteus.mprans import Kappa
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+triangleOptions = mesh.triangleOptions
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_cfl_controller
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = Kappa.NumericalFlux
+conservativeFlux  = None
+subgridError      = Kappa.SubgridError(coefficients=physics.coefficients,nd=ct.nd)
+shockCapturing    = Kappa.ShockCapturing(physics.coefficients,ct.nd,shockCapturingFactor=ct.kappa_shockCapturingFactor,
+                                         lag=ct.kappa_lag_shockCapturing)
+
+fullNewtonFlag  = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+#printNonlinearSolverInfo = True
+matrix = SparseMatrix
+if not ct.useOldPETSc and not ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+else:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'kappa_'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'rits'
+
+tolFac = 0.0
+linTolFac =0.0
+l_atol_res = 0.001*ct.kappa_nl_atol_res
+nl_atol_res = ct.kappa_nl_atol_res
+useEisenstatWalker = False
+
+maxNonlinearIts = 10
+maxLineSearches = 0
+
+auxiliaryVariables = ct.domain.auxiliaryVariables['kappa']
+

--- a/2d/sediment/sediment_erosion/kappa_p.py
+++ b/2d/sediment/sediment_erosion/kappa_p.py
@@ -1,0 +1,50 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import Kappa
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = Kappa.LevelModel
+
+dissipation_model_flag = 1
+if ct.useRANS >= 2:
+    dissipation_model_flag=2
+
+coefficients = Kappa.Coefficients(V_model=ct.V_model,
+                                  ME_model=ct.K_model,
+                                  LS_model=ct.LS_model,
+                                  RD_model=ct.RD_model,
+                                  dissipation_model=ct.EPS_model,
+                                  SED_model=ct.SED_model,
+                                  dissipation_model_flag=dissipation_model_flag+int(ct.movingDomain),#1 -- K-epsilon, 2 -- K-omega
+                                  useMetrics=useMetrics,
+                                  rho_0=rho_0,nu_0=nu_0,
+                                  rho_1=rho_1,nu_1=nu_1,
+                                  g=g,
+                                  nd = ct.nd,
+                                  c_mu=ct.opts.Cmu,sigma_k=ct.opts.sigma_k, 
+                                  sc_uref=kappa_sc_uref,
+                                  sc_beta=kappa_sc_beta,
+                                  closure = ct.sedClosure)
+
+kInflow=ct.kInflow
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].k_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].k_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {},
+                                   1: {1: lambda x, flag: domain.bc[flag].k_diffusive.init_cython()},
+                                  }
+
+
+class ConstantIC:
+    def __init__(self,cval=0.0):
+        self.cval=cval
+    def uOfXT(self,x,t):
+        return self.cval
+
+   
+initialConditions  = {0:ConstantIC(cval=kInflow)}

--- a/2d/sediment/sediment_erosion/ls_consrv_n.py
+++ b/2d/sediment/sediment_erosion/ls_consrv_n.py
@@ -1,0 +1,78 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools,
+                     NumericalFlux)
+import ls_consrv_p as physics
+from proteus import Context
+from proteus.mprans.MCorr3P import DummyNewton
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+#time stepping
+runCFL = ct.runCFL
+timeIntegrator  = TimeIntegration.ForwardIntegrator
+timeIntegration = TimeIntegration.NoIntegration
+
+#mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0:ct.basis}
+
+subgridError      = None
+massLumping       = False
+numericalFluxType = ct.DoNothing
+conservativeFlux  = None
+shockCapturing    = None
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+#multilevelNonlinearSolver = DummyNewton
+#levelNonlinearSolver      = DummyNewton
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'mcorr_'
+nonlinearSolverConvergenceTest  = 'rits'
+levelNonlinearSolverConvergenceTest  = 'rits'
+linearSolverConvergenceTest  = 'r-true'
+
+tolFac = 0.0
+linTolFac = 0.01
+l_atol_res = 0.01*ct.mcorr_nl_atol_res
+nl_atol_res = ct.mcorr_nl_atol_res
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0

--- a/2d/sediment/sediment_erosion/ls_consrv_p.py
+++ b/2d/sediment/sediment_erosion/ls_consrv_p.py
@@ -1,0 +1,40 @@
+from proteus import StepControl
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import MCorr3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+
+LevelModelType = MCorr3P.LevelModel
+
+coefficients = MCorr3P.Coefficients(LS_model=ct.LS_model,
+                                    V_model=ct.V_model,
+                                    ME_model=ct.MCORR_model,
+                                    VOF_model=ct.VOF_model,
+                                    VOS_model=ct.VOS_model,
+                                    applyCorrection=ct.applyCorrection,
+                                    nd=nd,
+                                    checkMass=False,
+                                    useMetrics=ct.useMetrics,
+                                    epsFactHeaviside=ct.epsFact_consrv_heaviside,
+                                    epsFactDirac=ct.epsFact_consrv_dirac,
+                                    epsFactDiffusion=ct.epsFact_consrv_diffusion)
+
+class zero_phi:
+    def __init__(self):
+        pass
+    def uOfX(self,X):
+        return 0.0
+    def uOfXT(self,X,t):
+        return 0.0
+
+initialConditions  = {0:zero_phi()}

--- a/2d/sediment/sediment_erosion/ls_n.py
+++ b/2d/sediment/sediment_erosion/ls_n.py
@@ -1,0 +1,78 @@
+from proteus import StepControl
+from proteus.default_n import *
+import ls_p as physics
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+from proteus.mprans import NCLS3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+coefficients = physics.coefficients
+
+# time stepping
+runCFL = ct.runCFL
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_controller
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0: ct.basis}
+
+massLumping       = False
+conservativeFlux  = None
+numericalFluxType = NCLS3P.NumericalFlux
+subgridError      = NCLS3P.SubgridError(coefficients,nd)
+shockCapturing    = NCLS3P.ShockCapturing(coefficients,nd,shockCapturingFactor=ct.ls_shockCapturingFactor,lag=ct.ls_lag_shockCapturing)
+
+fullNewtonFlag  = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'ncls_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'r-true'
+
+tolFac = 0.0
+nl_atol_res = ct.ls_nl_atol_res
+linTolFac = 0.0
+l_atol_res = 0.1*ct.ls_nl_atol_res
+
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+
+auxiliaryVariables = ct.domain.auxiliaryVariables['ls']

--- a/2d/sediment/sediment_erosion/ls_p.py
+++ b/2d/sediment/sediment_erosion/ls_p.py
@@ -1,0 +1,39 @@
+from proteus import StepControl
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import NCLS3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+
+LevelModelType = NCLS3P.LevelModel
+
+coefficients = NCLS3P.Coefficients(V_model=ct.V_model,
+                                   RD_model=ct.RD_model,
+                                   ME_model=ct.LS_model,
+                                   checkMass=False,
+                                   useMetrics=ct.useMetrics,
+                                   epsFact=ct.epsFact_consrv_heaviside,
+                                   sc_uref=ct.ls_sc_uref,
+                                   sc_beta=ct.ls_sc_beta,
+                                   movingDomain=ct.movingDomain)
+
+dirichletConditions = {0: lambda x, flag: None}
+
+advectiveFluxBoundaryConditions = {}
+
+diffusiveFluxBoundaryConditions = {0: {}}
+
+class PHI_IC:
+    def uOfXT(self, x, t):
+        return x[nd-1] - ct.waterLevel
+
+initialConditions = {0: PHI_IC()}

--- a/2d/sediment/sediment_erosion/pressureInitial_n.py
+++ b/2d/sediment/sediment_erosion/pressureInitial_n.py
@@ -1,0 +1,54 @@
+from proteus import *
+from proteus.default_n import *
+from pressureInitial_p import *
+
+
+mesh = domain.MeshOptions
+triangleOptions = triangleOptions
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+
+femSpaces = {0:ct.pbasis}
+
+stepController=FixedStep
+
+#numericalFluxType = NumericalFlux.ConstantAdvection_Diffusion_SIPG_exterior #weak boundary conditions (upwind ?)
+matrix = LinearAlgebraTools.SparseMatrix
+
+#linearSmoother    = LinearSolvers.NavierStokesPressureCorrection # pure neumann laplacian solver
+#multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+#levelLinearSolver = LinearSolvers.KSP_petsc4py
+#linearSmoother    = None
+#multilevelLinearSolver = LinearSolvers.LU
+#levelLinearSolver      = LinearSolvers.LU
+numericalFluxType = NumericalFlux.ConstantAdvection_exterior
+#numericalFluxType = NumericalFlux
+
+linear_solver_options_prefix = 'pinit_'
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+else:
+    multilevelLinearSolver = KSP_petsc4py
+    levelLinearSolver      = KSP_petsc4py
+    parallelPartitioningType    = parallelPartitioningType
+    nLayersOfOverlapForParallel = nLayersOfOverlapForParallel
+    nonlinearSmoother = None
+    linearSmoother    = None
+
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+#linear solve rtolerance
+
+linTolFac = 0.0
+l_atol_res = 0.01*ct.phi_nl_atol_res
+tolFac = 0.0
+nl_atol_res = ct.phi_nl_atol_res
+nonlinearSolverConvergenceTest = 'r'
+levelNonlinearSolverConvergenceTest = 'r'
+linearSolverConvergenceTest             = 'r-true'
+maxLineSearches=0
+periodicDirichletConditions=None
+
+conservativeFlux=None

--- a/2d/sediment/sediment_erosion/pressureInitial_p.py
+++ b/2d/sediment/sediment_erosion/pressureInitial_p.py
@@ -1,0 +1,43 @@
+from math import *
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import PresInit
+from proteus import Context
+from tank import *
+
+ct = Context.get()
+name = "pressureInitial"
+
+coefficients=PresInit.Coefficients(nd=nd,
+                                   modelIndex=ct.PI_model,
+                                   fluidModelIndex=ct.V_model,
+                                   pressureModelIndex=ct.P_model)
+
+#pressure increment should be zero on any pressure dirichlet boundaries
+
+#the advectiveFlux should be zero on any no-flow  boundaries
+
+
+class getIBC_pInit:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+class PerturbedSurface_p:
+    def __init__(self,waterLevel):
+        self.waterLevel=waterLevel
+    def uOfXT(self,x,t):
+        self.vos = ct.vos_function(x)
+        self.rho_a = rho_1#(1.-self.vos)*rho_1 + (self.vos)*ct.rho_s
+        self.rho_w = rho_0#(1.-self.vos)*rho_0 + (self.vos)*ct.rho_s
+        if signedDistance(x) < 0:
+            return -(L[1] - self.waterLevel)*self.rho_a*g[1] - (self.waterLevel - x[1])*self.rho_w*g[1]
+        else:
+            return -(L[1] - x[1])*self.rho_a*g[1]
+
+initialConditions = {0:PerturbedSurface_p(waterLine_z)} #getIBC_pInit()}
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].pInit_dirichlet.init_cython()}
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].pInit_advective.init_cython()}
+diffusiveFluxBoundaryConditions = {0:{0: lambda x, flag: domain.bc[flag].pInit_diffusive.init_cython()}}

--- a/2d/sediment/sediment_erosion/pressure_n.py
+++ b/2d/sediment/sediment_erosion/pressure_n.py
@@ -1,0 +1,53 @@
+from proteus import *
+from proteus.default_n import *
+from pressure_p import *
+
+
+mesh = domain.MeshOptions
+triangleOptions = triangleOptions
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+
+femSpaces = {0:ct.pbasis}
+
+
+# stepController  = StepControl.Min_dt_cfl_controller
+# runCFL= 0.99
+# runCFL= 0.5
+
+stepController=FixedStep
+
+#matrix type
+numericalFluxType = NumericalFlux.ConstantAdvection_exterior
+#numericalFluxType = NumericalFlux
+matrix = LinearAlgebraTools.SparseMatrix
+
+linear_solver_options_prefix = 'pressure_'
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+else:
+    multilevelLinearSolver = KSP_petsc4py
+    levelLinearSolver      = KSP_petsc4py
+    parallelPartitioningType    = parallelPartitioningType
+    nLayersOfOverlapForParallel = nLayersOfOverlapForParallel
+    nonlinearSmoother = None
+    linearSmoother    = None
+
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+#linear solve rtolerance
+
+linTolFac = 0.0
+l_atol_res = 0.1*ct.pressure_nl_atol_res
+tolFac = 0.0
+nl_atol_res = ct.pressure_nl_atol_res
+maxLineSearches = 0
+nonlinearSolverConvergenceTest      = 'r'
+levelNonlinearSolverConvergenceTest = 'r'
+linearSolverConvergenceTest         = 'r-true'
+
+periodicDirichletConditions=None
+
+conservativeFlux=None

--- a/2d/sediment/sediment_erosion/pressure_p.py
+++ b/2d/sediment/sediment_erosion/pressure_p.py
@@ -1,0 +1,34 @@
+from math import *
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import Pres
+from proteus import Context
+from tank import *
+
+ct = Context.get()
+name = "pressure"
+
+LevelModelType = Pres.LevelModel
+
+coefficients=Pres.Coefficients(modelIndex=ct.P_model,
+                               fluidModelIndex=ct.V_model,
+                               pressureIncrementModelIndex=ct.DP_model,
+                               useRotationalForm=True)
+
+
+class getIBC_p:
+    def __init__(self,waterLevel):
+        self.waterLevel=waterLevel
+    def uOfXT(self,x,t):
+        self.vos = ct.vos_function(x)
+        self.rho_a = rho_1#(1.-self.vos)*rho_1 + (self.vos)*ct.rho_s
+        self.rho_w = rho_0#(1.-self.vos)*rho_0 + (self.vos)*ct.rho_s
+        if signedDistance(x) < 0:
+            return -(L[1] - self.waterLevel)*self.rho_a*g[1] - (self.waterLevel - x[1])*self.rho_w*g[1]
+        else:
+            return -(L[1] - x[1])*self.rho_a*g[1]
+
+initialConditions = {0:getIBC_p(waterLine_z)}
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].p_dirichlet.init_cython() } # pressure bc are explicitly set
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].pInit_advective.init_cython()}

--- a/2d/sediment/sediment_erosion/pressureincrement_n.py
+++ b/2d/sediment/sediment_erosion/pressureincrement_n.py
@@ -1,0 +1,56 @@
+from proteus import *
+from proteus.default_n import *
+from pressureincrement_p import *
+
+mesh = domain.MeshOptions
+triangleOptions = triangleOptions
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+
+femSpaces = {0:pbasis}
+
+stepController=FixedStep
+
+#numericalFluxType = PresInc.NumericalFlux
+numericalFluxType = NumericalFlux.ConstantAdvection_exterior
+matrix = LinearAlgebraTools.SparseMatrix
+
+#if openTop:
+#    linearSmoother    = None
+#    multilevelLinearSolver = LinearSolvers.LU
+#    levelLinearSolver      = LinearSolvers.LU
+#else:
+#    linearSmoother         = LinearSolvers.NavierStokesPressureCorrection # pure neumann laplacian solver
+#    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+#    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+linear_solver_options_prefix = 'phi_'
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+else:
+    multilevelLinearSolver = KSP_petsc4py
+    levelLinearSolver      = KSP_petsc4py
+    parallelPartitioningType    = parallelPartitioningType
+    nLayersOfOverlapForParallel = nLayersOfOverlapForParallel
+    nonlinearSmoother = None
+    linearSmoother    = None
+
+
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+#linear solve rtolerance
+
+linTolFac = 0.0
+l_atol_res = 0.01*phi_nl_atol_res
+tolFac = 0.0
+nl_atol_res = phi_nl_atol_res
+nonlinearSolverConvergenceTest = 'r'
+levelNonlinearSolverConvergenceTest = 'r'
+linearSolverConvergenceTest             = 'r-true'
+maxLineSearches=0
+periodicDirichletConditions=None
+
+conservativeFlux = {0:'point-eval'} #'point-eval','pwl-bdm-opt'
+#conservativeFlux=None

--- a/2d/sediment/sediment_erosion/pressureincrement_p.py
+++ b/2d/sediment/sediment_erosion/pressureincrement_p.py
@@ -1,0 +1,50 @@
+from math import *
+from proteus import *
+from proteus.default_p import *
+from tank import *
+import tank_so
+from proteus.mprans import PresInc
+from proteus import Context
+
+ct = Context.get()
+
+
+#domain = ctx.domain
+#nd = ctx.nd
+name = "pressureincrement"
+
+LevelModelType = PresInc.LevelModel
+#from ProjectionScheme import PressureIncrement
+#coefficients=PressureIncrement(rho_f_min = rho_1,
+#                               rho_s_min = rho_s,
+#                               nd = nd,
+#                               modelIndex=PINC_model,
+#                               fluidModelIndex=V_model)
+from proteus.mprans import PresInc
+coefficients=PresInc.Coefficients(rho_f_min = (1.0-1.0e-8)*rho_1,
+                                  rho_s_min = (1.0-1.0e-8)*rho_s,
+                                  nd = nd,
+                                  modelIndex= ct.DP_model,
+                                  fluidModelIndex= ct.V_model,
+                                  sedModelIndex= ct.SED_model,
+                                  VOF_model= ct.VOF_model,
+                                  VOS_model= ct.VOS_model,
+                                  fixNullSpace=fixNullSpace_PresInc, 
+                                  INTEGRATE_BY_PARTS_DIV_U=ct.INTEGRATE_BY_PARTS_DIV_U_PresInc)
+
+
+#pressure increment should be zero on any pressure dirichlet boundaries
+
+#the advectiveFlux should be zero on any no-flow  boundaries
+
+class getIBC_phi:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+initialConditions = {0:getIBC_phi()}
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].pInc_dirichlet.init_cython()}
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].pInc_advective.init_cython()}
+diffusiveFluxBoundaryConditions = {0:{0: lambda x, flag: domain.bc[flag].pInc_diffusive.init_cython()}}

--- a/2d/sediment/sediment_erosion/redist_n.py
+++ b/2d/sediment/sediment_erosion/redist_n.py
@@ -1,0 +1,95 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools,
+                     NumericalFlux)
+from proteus.mprans import RDLS3P
+import redist_p as physics
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+# time stepping
+runCFL = ct.runCFL
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0: ct.basis}
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+massLumping       = False
+numericalFluxType = NumericalFlux.DoNothing
+conservativeFlux  = None
+subgridError      = RDLS3P.SubgridError(physics.coefficients,nd)
+shockCapturing    = RDLS3P.ShockCapturing(physics.coefficients,nd,shockCapturingFactor=ct.rd_shockCapturingFactor,lag=ct.rd_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver  = NonlinearSolvers.Newton
+levelNonlinearSolver       = NonlinearSolvers.Newton
+
+nonlinearSmoother = NonlinearSolvers.NLGaussSeidel
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+if ct.redist_Newton:
+    timeIntegration = NoIntegration
+    stepController = ct.Newton_controller
+    maxNonlinearIts = 50
+    maxLineSearches = 0
+    nonlinearSolverConvergenceTest = 'rits'
+    levelNonlinearSolverConvergenceTest = 'rits'
+    linearSolverConvergenceTest = 'r-true'
+    useEisenstatWalker = False
+else:
+    timeIntegration = BackwardEuler_cfl
+    stepController = RDLS3P.PsiTC
+    runCFL=2.0
+    psitc['nStepsForce']=3
+    psitc['nStepsMax']=50
+    psitc['reduceRatio']=10.0
+    psitc['startRatio']=1.0
+    rtol_res[0] = 0.0
+    atol_res[0] = rd_nl_atol_res
+    useEisenstatWalker = False#True
+    maxNonlinearIts = 1
+    maxLineSearches = 0
+    nonlinearSolverConvergenceTest = 'rits'
+    levelNonlinearSolverConvergenceTest = 'rits'
+    linearSolverConvergenceTest = 'r-true'
+
+linear_solver_options_prefix = 'rdls_'
+
+tolFac = 0.0
+nl_atol_res = ct.rd_nl_atol_res
+linTolFac = 0.01
+l_atol_res = 0.01*ct.rd_nl_atol_res
+useEisenstatWalker = False#True

--- a/2d/sediment/sediment_erosion/redist_p.py
+++ b/2d/sediment/sediment_erosion/redist_p.py
@@ -1,0 +1,46 @@
+from proteus import StepControl
+from proteus import *
+from proteus.default_p import *
+from math import *
+from proteus.mprans import RDLS3P
+from proteus import Context
+
+"""
+The redistancing equation in the sloshbox test problem.
+"""
+
+ct = Context.get()
+domain = ct.domain
+nd = domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+
+LevelModelType = RDLS3P.LevelModel
+
+
+
+coefficients = RDLS3P.Coefficients(applyRedistancing=ct.applyRedistancing,
+                                   epsFact=ct.epsFact_redistance,
+                                   nModelId=ct.LS_model,
+                                   rdModelId=ct.RD_model,
+                                   useMetrics=ct.useMetrics,
+                                   backgroundDiffusionFactor=ct.backgroundDiffusionFactor)
+
+def getDBC_rd(x,flag):
+    pass
+
+dirichletConditions     = {0:getDBC_rd}
+weakDirichletConditions = {0:RDLS3P.setZeroLSweakDirichletBCsSimple}
+
+advectiveFluxBoundaryConditions =  {}
+diffusiveFluxBoundaryConditions = {0:{}}
+
+class PHI_IC:
+    def uOfXT(self, x, t):
+        return x[nd-1] - ct.waterLevel
+
+initialConditions  = {0: PHI_IC()}

--- a/2d/sediment/sediment_erosion/runTest
+++ b/2d/sediment/sediment_erosion/runTest
@@ -1,0 +1,3 @@
+# Single phase
+parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=.01 rho_1=998.2 nu_1=1e-6 cSed=0.6 inflow_vel=.1" -D caseTest
+

--- a/2d/sediment/sediment_erosion/tank.py
+++ b/2d/sediment/sediment_erosion/tank.py
@@ -1,0 +1,635 @@
+from proteus import StepControl
+from math import *
+import proteus.MeshTools
+from proteus import Domain, Context
+from proteus.default_n import *
+from proteus.Profiling import logEvent
+from proteus.mprans import SpatialTools as st
+from proteus import Gauges as ga
+from proteus import WaveTools as wt
+from proteus.mprans.SedClosure import  HsuSedStress
+from proteus.mprans import BoundaryConditions as bc
+
+opts=Context.Options([
+    # Geometry and sed parameters
+    ("waterLine_x", 20., "Width of free surface from left to right"),
+    ("waterLine_z", .5, "Heigth of free surface above bottom"),
+    ("sediment_level", 0.24, "Height of the sediment column"),
+    ("sediment_bottom", -20., "Height of the sediment column"),
+    ("Lx", 12., "Length of the numerical domain"),
+    ("Ly", 1., "Heigth of the numerical domain"),
+    ("wHole", 2., "Width of hole"),
+    ("dtout", 0.05, "Time interval for output"),
+    #Current
+    ("inflow_vel", 0.1, "Inflow velocity (at x direction)"),
+    ("ramp",1.,"Ramping time"),
+    ("I",0.03,"Turbulence intensity"),
+    #fluid parameters
+    ("rho_0", 998.2, "water density"),
+    ("rho_1", 998.2, "air density"),
+    ("nu_0", 1e-6, "water kin viscosity"),
+    ("nu_1", 1e-6, "air kin viscosity"),
+    ('g',np.array([0.0, -9.8, 0.0]),'Gravitational acceleration'),    
+    # sediment parameters
+    ('cSed', 0.6,'Initial sediment concentration'),
+    ('rho_s',2600 ,'sediment material density'),
+    ('alphaSed', 150.,'laminar drag coefficient'),
+    ('betaSed', 1.72,'turbulent drag coefficient'),
+    ('grain',0.0025, 'Grain size'),
+    ('packFraction',0.2,'threshold for loose / packed sediment'),
+    ('packMargin',0.01,'transition margin for loose / packed sediment'),
+    ('maxFraction',0.635,'fraction at max  sediment packing'),
+    ('frFraction',0.57,'fraction where contact stresses kick in'),
+    ('sigmaC',0.57,'Schmidt coefficient for turbulent diffusion'),
+    ('C3e',1.2,'Dissipation coefficient '),
+    ('C4e',1.2,'Dissipation coefficient'),
+    ('eR', 0.8, 'Collision stress coefficient (module not functional)'),
+    ('fContact', 0.05,'Contact stress coefficient'),
+    ('mContact', 3.0,'Contact stress coefficient'),
+    ('nContact', 5.0,'Contact stress coefficient'),
+    ('angFriction', pi/6., 'Angle of friction'),
+    ('vos_limiter', 0.6, 'Weak limiter for vos'),
+    ('mu_fr_limiter', 1e-3,'Hard limiter for contact stress friction coeff'),
+     # numerical options
+    ("refinement", 25.,"Ly/refinement"),
+    ("sedimentDynamics", True, "Enable sediment dynamics module"),
+    ("cfl", 0.5 ,"Target cfl"),
+    ("duration", 1.0 ,"Duration of the simulation"),
+    ("PSTAB", 1.0, "Affects subgrid error"),
+    ("res", 1.0e-8, "Residual tolerance"),
+    ("kres", 1.0e-2, "Residual tolerance for k-epsilon"),
+    ("epsFact_density", 3.0, "Control width of water/air transition zone"),
+    ("epsFact_consrv_diffusion", 1.0, "Affects smoothing diffusion in mass conservation"),
+    ("useRANS", 1, "Switch ON turbulence models: 0-None, 1-K-Epsilon, 2-K-Omega1998, 3-K-Omega1988"),
+    ("vos_SC",0.9,"vos shock capturing"),
+    # ns_closure: 1-classic smagorinsky, 2-dynamic smagorinsky, 3-k-epsilon, 4-k-omega
+    ("sigma_k", 1.0, "sigma_k coefficient for the turbulence model"),
+    ("sigma_e", 1.0, "sigma_e coefficient for the turbulence model"),
+    ("K", 0.41, "von Karman coefficient for the turbulence model"),
+    ("B", 5.57, "Wall coefficient for the turbulence model"),
+    ("Cmu", 0.09, "Cmu coefficient for the turbulence model"),
+    ])
+
+# SO Models
+
+VOS_model = 0
+VOF_model = 1
+LS_model = 2
+RD_model = 3
+MCORR_model =4
+SED_model =5
+V_model =6
+DP_model = 7
+P_model = 8
+
+
+if opts.useRANS:
+    K_model = 9
+    EPS_model = 10
+    PI_model = 11
+else:
+    K_model = None
+    EPS_model = None   
+    PI_model = 9
+
+# Domain dimensions
+
+nd = 2
+
+
+# Turbulence and wall functions
+
+
+steady_current = wt.SteadyCurrent(U=np.array([opts.inflow_vel,0.,0.]),mwl=1e6,rampTime=opts.ramp)
+I = opts.I
+kInflow = 0.5*(opts.inflow_vel*I)**2
+Lturb = opts.Ly/6.
+dissipationInflow = (opts.Cmu**0.75) *(kInflow**1.5)/Lturb
+
+#Wall functions
+
+he = opts.Ly/opts.refinement
+Re = opts.inflow_vel*opts.Ly/opts.nu_0
+Y_ = he
+cf = 0.045*(Re**(-1./4.))
+Ut = opts.inflow_vel*sqrt(cf/2.)
+Yplus = Y_*Ut/opts.nu_0
+kappaP = (Ut**2)/sqrt(opts.Cmu)
+dissipationP = (Ut**3)/(opts.K*Y_)
+# ----- Sediment stress ----- #
+
+sedClosure = HsuSedStress(aDarcy =  opts.alphaSed,
+                          betaForch =  opts.betaSed,
+                          grain =  opts.grain,
+                          packFraction =  opts.packFraction,
+                          packMargin =  opts.packMargin,
+                          maxFraction =  opts.maxFraction,
+                          frFraction =  opts.frFraction,
+                          sigmaC =  opts.sigmaC,
+                          C3e =  opts.C3e,
+                          C4e =  opts.C4e,
+                          eR =  opts.eR,
+                          fContact =  opts.fContact,
+                          mContact =  opts.mContact,
+                          nContact =  opts.nContact,
+                          angFriction =  opts.angFriction,
+                          vos_limiter = opts.vos_limiter,
+                          mu_fr_limiter = opts.mu_fr_limiter,
+                          )
+
+# ----- DOMAIN ----- #
+
+domain = Domain.PlanarStraightLineGraphDomain()
+
+
+# ----- Phisical constants ----- #
+  
+# Water
+rho_0 = opts.rho_0
+nu_0 = opts.nu_0
+
+# Air
+rho_1 = opts.rho_1
+nu_1 = opts.nu_1
+
+# Sediment
+
+rho_s = opts.rho_s
+nu_s = 1000000
+dragAlpha = 0.0
+
+# Surface tension
+sigma_01 = 0.0
+
+# Gravity
+g = opts.g
+gamma_0 = abs(g[1])*rho_0
+
+# Initial condition
+waterLine_x = opts.waterLine_x
+waterLine_z = opts.waterLine_z
+sediment_level = opts.sediment_level
+sediment_bottom = opts.sediment_bottom
+waterLevel = waterLine_z
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Domain and mesh
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+#L = (opts.Lx, opts.Ly)
+#he = L[0]/opts.refinement
+
+#dim = dimx, dimy = L
+#coords = [ dimx/2., dimy/2. ]
+
+############ TANK ###################
+
+
+
+tank_dim = (opts.Lx, opts.Ly)
+
+xHoleCenter = opts.Lx/2.
+wHole = opts.wHole
+xHoleStart = xHoleCenter - wHole /2.
+xHoleEnd = xHoleStart+wHole
+x1 = xHoleCenter / 8.
+x2 = opts.Lx - xHoleCenter / 8.
+dHole = opts.Ly/4.
+
+
+
+
+### CYLINDER #####
+#cylinder_pos = np.array([opts.cylinder_pos_x, opts.cylinder_pos_y, 0.])
+#cylinder_radius = opts.cylinder_radius
+
+
+
+
+"""
+if opts.circle2D:
+    circle = st.Circle(domain=domain, radius=cylinder_radius, coords=(cylinder_pos[0],cylinder_pos[1]), barycenter=(cylinder_pos[0],cylinder_pos[1]), nPoints=28)
+
+    circle2D = bd.RigidBody(shape=circle)
+    free_x = (0.0,0.0,0.0)
+    free_r = (0.0,0.0,0.0)
+    circle2D.setConstraints(free_x=free_x,free_r=free_r)
+    circle2D.setNumericalScheme(None)
+    circle2D.setRecordValues(filename='circle2D',all_values=True)
+"""
+
+
+
+
+boundaryOrientations = {'y-': np.array([0., -1.,0.]),
+                        'x+': np.array([+1, 0.,0.]),
+                        'y+': np.array([0., +1.,0.]),
+                        'x-': np.array([-1., 0.,0.]),
+                        'sponge': None,
+                        'hole_x-': np.array([-1., 0.,0.]),
+                        'hole_x+': np.array([+1., 0.,0.]),
+                        'hole_y-': np.array([0., -1.,0.]),
+
+
+                           }
+boundaryTags = {'y-': 1,
+                    'x+': 2,
+                    'y+': 3,
+                    'x-': 4,
+                    'sponge': 5,
+                    'hole_x-':6,
+                    'hole_x+':7,
+                    'hole_y-':8,
+                       }
+
+
+
+
+
+vertices=[[0.0, dHole],#0
+              [x1,  dHole],#1
+              [xHoleStart,  dHole],#2
+              [xHoleStart,  0.0],#3
+              [xHoleEnd,  0.0],#4
+              [xHoleEnd,  dHole],#5
+              [x2,  dHole],#6
+              [tank_dim[0],dHole],#7
+              [tank_dim[0],tank_dim[1]], #8
+              [x2, tank_dim[1]], #9
+              [x1, tank_dim[1]], #10
+              [0.0, tank_dim[1]], #11
+              ]
+
+vertexFlags=np.array([4, 1, 1,
+                          8, 8,
+                          1, 1, 2,
+                          2, 3, 3, 4,
+                          ])
+segments=[[0,1],
+              [1,2],
+
+              [2,3],
+              [3,4],
+              [4,5],
+
+              [5,6],
+              [6,7],
+
+              [7,8],
+
+              [8,9],
+              [9,10],
+              [10,11],
+
+              [11,0],
+
+              [1,10],
+              [6,9],
+             ]
+
+segmentFlags=np.array([ 1, 1,
+                            6, 8, 7,
+                            1, 1,
+                            2,
+                            3, 3, 3,
+                            4,
+                            5, 5,
+                         ])
+
+
+regions = [ [ 0.90*x1 , 0.50*tank_dim[1] ],
+            [ 0.7 , 0.50*tank_dim[1] ],
+            [ 0.95*tank_dim[0] , 0.50*tank_dim[1] ] ]
+
+regionFlags=np.array([1, 2, 3])
+
+
+
+tank = st.CustomShape(domain, vertices=vertices, vertexFlags=vertexFlags,
+                      segments=segments, segmentFlags=segmentFlags,
+                      regions=regions, regionFlags=regionFlags,
+                      boundaryTags=boundaryTags, boundaryOrientations=boundaryOrientations)
+
+kWallWall = bc.kWall(Y=Y_, Yplus=Yplus, b_or=boundaryOrientations['y-'], nu=nu_0)
+kWalls = [kWallWall]
+wallWall = bc.WallFunctions(turbModel='ke', kWall=kWallWall, b_or=boundaryOrientations['y-'], Y=Y_, Yplus=Yplus, U0=[opts.inflow_vel, 0. , 0.], nu=nu_0, Cmu=opts.Cmu, K=opts.K, B=opts.B)
+walls = [wallWall]
+
+
+#############################################################################################################################################################################################################################################################################################################################################################################################
+# ----- BOUNDARY CONDITIONS ----- #
+#############################################################################################################################################################################################################################################################################################################################################################################################
+tank.setTurbulentWall(walls)
+tank.setTurbulentKWall(kWalls)
+#tank.BC['y-'].setFreeSlip()
+tank.BC['y-'].setWallFunction(walls[0])
+tank.BC['y+'].setFreeSlip()#.setAtmosphere(orientation=np.array([0., +1.,0.]),kInflow=kInflow,dInflow=dissipationInflow)
+
+tank.BC['x-'].setUnsteadyTwoPhaseVelocityInlet(wave=steady_current, smoothing = 3*he, vert_axis=1, kInflow = kInflow, dInflow = dissipationInflow)
+#tank.BC['x-'].setFreeSlip()
+
+tank.BC['x+'].setHydrostaticPressureOutletWithDepth(seaLevel=opts.waterLine_z,
+                                                    rhoUp=rho_1,
+                                                    rhoDown=rho_0,
+                                                    g=g,
+                                                    refLevel=opts.Ly,
+                                                    smoothing=opts.epsFact_density*he,
+                                                    kInflow=kInflow, dissipationInflow=dissipationInflow,
+                                                    kInflowAir=kInflow, dissipationInflowAir=dissipationInflow)
+#tank.BC['x+'].setFreeSlip()
+
+
+
+
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Turbulence
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+
+tank.BC['hole_x+'].setNoSlip()
+tank.BC['hole_x-'].setNoSlip()
+tank.BC['hole_y-'].setNoSlip()
+
+
+######################################################################################################################################################################################################################
+# Gauges and probes #
+######################################################################################################################################################################################################################
+
+T=opts.duration
+PG = []
+gauge_dy=0.01
+tank_dim_y=opts.Ly
+nprobes=int(tank_dim_y/gauge_dy)+1
+probes=np.linspace(0., tank_dim_y, nprobes)
+for i in probes:
+    PG.append((opts.Lx/2., i, 0.),)
+v_output = ga.PointGauges(gauges=((('u',), PG),
+                                  (('v',), PG),),
+                          activeTime = (0., T),
+                          sampleRate=0.,
+                          fileName='fluidVelocityGauges.csv')
+vs_output = ga.PointGauges(gauges=((('us',),PG), 
+                                   (('vs',),PG),),
+                          activeTime = (0., T),
+                          sampleRate=0.,
+                          fileName='solidVelocityGauges.csv')
+vos_output = ga.PointGauges(gauges=((('vos',),PG),),
+                          activeTime = (0., T),
+                          sampleRate=0.,
+                          fileName='solidFractionGauges.csv')
+
+
+######################################################################################################################################################################################################################
+# Numerical Options and other parameters #
+######################################################################################################################################################################################################################
+ 
+domain.MeshOptions.he = he
+
+from math import *
+from proteus import MeshTools, AuxiliaryVariables
+import numpy
+import proteus.MeshTools
+from proteus import Domain
+from proteus.Profiling import logEvent
+from proteus.default_n import *
+from proteus.ctransportCoefficients import smoothedHeaviside
+from proteus.ctransportCoefficients import smoothedHeaviside_integral
+
+st.assembleDomain(domain)
+
+
+#----------------------------------------------------
+# Time stepping and velocity
+#----------------------------------------------------
+
+T=opts.duration
+weak_bc_penalty_constant = 10.0/nu_0 #100
+dt_fixed = opts.dtout
+dt_init = min(0.1*dt_fixed,0.001)
+nDTout= int(round(T/dt_fixed))
+runCFL = opts.cfl
+
+sedimentDynamics=opts.sedimentDynamics
+
+#----------------------------------------------------
+#  Discretization -- input options
+#----------------------------------------------------
+
+genMesh = True
+movingDomain = False
+applyRedistancing = True
+useOldPETSc = False
+useSuperlu = False
+timeDiscretization = 'be'#'vbdf'#'vbdf'  # 'vbdf', 'be', 'flcbdf'
+spaceOrder = 1
+pspaceOrder = 1
+useHex = False
+useRBLES = 0.0
+useMetrics = 1.0
+applyCorrection = True
+useVF = 1.0
+useOnlyVF = False
+useRANS = opts.useRANS  # 0 -- None
+                        # 1 -- K-Epsilon
+                        # 2 -- K-Omega
+
+
+KILL_PRESSURE_TERM = False
+fixNullSpace_PresInc = True
+INTEGRATE_BY_PARTS_DIV_U_PresInc = True
+CORRECT_VELOCITY = True
+STABILIZATION_TYPE = 0 #0: SUPG, 1: EV via weak residual, 2: EV via strong residual
+
+# Input checks
+if spaceOrder not in [1, 2]:
+    print "INVALID: spaceOrder" + spaceOrder
+    sys.exit()
+
+if useRBLES not in [0.0, 1.0]:
+    print "INVALID: useRBLES" + useRBLES
+    sys.exit()
+
+if useMetrics not in [0.0, 1.0]:
+    print "INVALID: useMetrics"
+    sys.exit()
+
+#  Discretization
+nd = tank.nd
+
+if spaceOrder == 1:
+    hFactor = 1.0
+    if useHex:
+        basis = C0_AffineLinearOnCubeWithNodalBasis
+        elementQuadrature = CubeGaussQuadrature(nd, 2)
+        elementBoundaryQuadrature = CubeGaussQuadrature(nd - 1, 2)
+    else:
+        basis = C0_AffineLinearOnSimplexWithNodalBasis
+        elementQuadrature = SimplexGaussQuadrature(nd, 3)
+        elementBoundaryQuadrature = SimplexGaussQuadrature(nd - 1, 3)
+elif spaceOrder == 2:
+    hFactor = 0.5
+    if useHex:
+        basis = C0_AffineLagrangeOnCubeWithNodalBasis
+        elementQuadrature = CubeGaussQuadrature(nd, 4)
+        elementBoundaryQuadrature = CubeGaussQuadrature(nd - 1, 4)
+    else:
+        basis = C0_AffineQuadraticOnSimplexWithNodalBasis
+        elementQuadrature = SimplexGaussQuadrature(nd, 4)
+        elementBoundaryQuadrature = SimplexGaussQuadrature(nd - 1, 4)
+
+if pspaceOrder == 1:
+    if useHex:
+        pbasis = C0_AffineLinearOnCubeWithNodalBasis
+    else:
+        pbasis = C0_AffineLinearOnSimplexWithNodalBasis
+elif pspaceOrder == 2:
+    if useHex:
+        pbasis = C0_AffineLagrangeOnCubeWithNodalBasis
+    else:
+        pbasis = C0_AffineQuadraticOnSimplexWithNodalBasis
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Numerical parameters
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+ns_forceStrongDirichlet = False
+ns_sed_forceStrongDirichlet = False
+backgroundDiffusionFactor=0.01
+
+if useMetrics:
+    ns_shockCapturingFactor = 0.5
+    ns_lag_shockCapturing = True
+    ns_lag_subgridError = True
+    ns_sed_shockCapturingFactor = 0.5
+    ns_sed_lag_shockCapturing = True
+    ns_sed_lag_subgridError = True
+    ls_shockCapturingFactor = 0.5
+    ls_lag_shockCapturing = True
+    ls_sc_uref = 1.0
+    ls_sc_beta = 1.0
+    vof_shockCapturingFactor = 0.5
+    vof_lag_shockCapturing = True
+    vof_sc_uref = 1.0
+    vof_sc_beta = 1.0
+    vos_shockCapturingFactor =  opts.vos_SC # <------------------------------------- 
+    vos_lag_shockCapturing = True
+    vos_sc_uref = 1.0
+    vos_sc_beta = 1.0
+    rd_shockCapturingFactor = 0.5
+    rd_lag_shockCapturing = False
+    epsFact_vos =opts.epsFact_density
+    epsFact_density = opts.epsFact_density # 1.5
+    epsFact_viscosity = epsFact_curvature = epsFact_vof = epsFact_consrv_heaviside = epsFact_consrv_dirac = epsFact_density
+    epsFact_redistance = 0.33
+    epsFact_consrv_diffusion = opts.epsFact_consrv_diffusion # 0.1
+    redist_Newton = True
+    kappa_shockCapturingFactor = 0.5
+    kappa_lag_shockCapturing = True #False
+    kappa_sc_uref = 1.0
+    kappa_sc_beta = 1.5
+    dissipation_shockCapturingFactor = 0.5
+    dissipation_lag_shockCapturing = True #False
+    dissipation_sc_uref = 1.0
+    dissipation_sc_beta = 1.5
+else:
+    ns_shockCapturingFactor = 0.9
+    ns_lag_shockCapturing = True
+    ns_lag_subgridError = True
+    ns_sed_shockCapturingFactor = 0.9
+    ns_sed_lag_shockCapturing = True
+    ns_sed_lag_subgridError = True
+    ls_shockCapturingFactor = 0.9
+    ls_lag_shockCapturing = True
+    ls_sc_uref = 1.0
+    ls_sc_beta = 1.0
+    vof_shockCapturingFactor = 0.9
+    vof_lag_shockCapturing = True
+    vof_sc_uref = 1.0
+    vof_sc_beta = 1.0
+    vos_shockCapturingFactor = .9
+    vos_lag_shockCapturing = True
+    vos_sc_uref = 1.0
+    vos_sc_beta = 1.0
+    rd_shockCapturingFactor = 0.9
+    rd_lag_shockCapturing = False
+    epsFact_density = opts.epsFact_density # 1.5
+    epsFact_viscosity = epsFact_curvature = epsFact_vof = epsFact_vos = epsFact_consrv_heaviside = epsFact_consrv_dirac = epsFact_density
+    epsFact_redistance = 0.33
+    epsFact_consrv_diffusion = opts.epsFact_consrv_diffusion # 1.0
+    redist_Newton = False
+    kappa_shockCapturingFactor = 0.5
+    kappa_lag_shockCapturing = True  #False
+    kappa_sc_uref = 1.0
+    kappa_sc_beta = 1.5
+    dissipation_shockCapturingFactor = 0.5
+    dissipation_lag_shockCapturing = True  #False
+    dissipation_sc_uref = 1.0
+    dissipation_sc_beta = 1.5
+
+ns_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+ns_sed_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+vof_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+vos_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+ls_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+rd_nl_atol_res =  max(opts.res, 0.005 * he)
+mcorr_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+kappa_nl_atol_res = max(1.0e-12,0.001*he**2)
+dissipation_nl_atol_res = max(1.0e-12,0.001*he**2)
+#kappa_nl_atol_res =  max(opts.kres, 0.01 * he ** 2)
+#dissipation_nl_atol_res =  max(opts.kres, 0.01 * he ** 2)
+phi_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+pressure_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Turbulence
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+ns_closure = 0  #1-classic smagorinsky, 2-dynamic smagorinsky, 3 -- k-epsilon, 4 -- k-omega
+ns_sed_closure = 0  #1-classic smagorinsky, 2-dynamic smagorinsky, 3 -- k-epsilon, 4 -- k-omega
+if useRANS == 1:
+    ns_closure = 3
+elif useRANS == 2:
+    ns_closure == 4
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Functions for model variables - Initial conditions
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+def signedDistance(x):
+    phi_z = x[1] - waterLine_z
+    return phi_z
+
+def vos_signedDistance(x):
+    phi_z1 = x[1] - sediment_level
+    phi_z2 = sediment_bottom - x[1]
+    if abs(phi_z1) < abs(phi_z2):
+        phi_z = phi_z1
+    else:
+        phi_z = phi_z2
+    Lsed  =   xHoleCenter - wHole/2.
+    if (x[0] <Lsed or  (x[0] > opts.Lx - Lsed)):
+        phi_z = 1
+    return phi_z
+
+class Suspension_class:
+    def __init__(self):
+        pass
+    def uOfXT(self, x, t=0):
+        phi = vos_signedDistance(x)
+        smoothing = (epsFact_consrv_heaviside)*he/2.
+        Heav = smoothedHeaviside(smoothing, phi)      
+        if phi <= -smoothing:
+            return opts.cSed
+        elif -smoothing < phi < smoothing:
+            return opts.cSed * (1.-Heav)            
+        else:
+            return 1e-10    
+
+Suspension = Suspension_class()
+
+vos_function = Suspension.uOfXT

--- a/2d/sediment/sediment_erosion/tank_old.py
+++ b/2d/sediment/sediment_erosion/tank_old.py
@@ -1,0 +1,600 @@
+from proteus import StepControl
+from math import *
+import proteus.MeshTools
+from proteus import Domain, Context
+from proteus.default_n import *
+from proteus.Profiling import logEvent
+from proteus.mprans import SpatialTools as st
+from proteus import Gauges as ga
+from proteus import WaveTools as wt
+from proteus.mprans.SedClosure import  HsuSedStress
+
+
+opts=Context.Options([
+    # Geometry and sed parameters
+    ("waterLine_x", 10.00, "Width of free surface from left to right"),
+    ("waterLine_z", 0.4, "Heigth of free surface above bottom"),
+    ("sediment_level", 0., "Height of the sediment column"),
+    ("sediment_bottom", -20., "Height of the sediment column"),
+    ("Lx", 1.6, "Length of the numerical domain"),
+    ("Ly", 0.6,"Heigth of the numerical domain"),
+    ("dtout", 0.05, "Time interval for output"),  
+    # cylinder
+    ("cylinder_radius", 0.05, "radius of cylinder"),
+    ("cylinder_pos_x", 0.8, "x position of cylinder"),
+    ("cylinder_pos_y", 0.085+0.05+0.16, "y position of cylinder"),
+    ("circle2D", False, "switch on/off cylinder"),
+    ("circleBC", 'NoSlip','circle BC'),
+    # hole
+    ("xHole", 0.3, "Distance of hole from inlet"),
+    ("dHole",0.24, " Hole depth"),
+    ("wHole",1.,"Hole width"),
+    # current
+    ("U", 1e-1, "inflow velocity"),
+    ("GenZone", not True, "on/off"),
+    ("AbsZone", not True, "on/off"),
+    #fluid parameters
+    ("rho_0", 998.2, "water density"),
+    ("rho_1", 1.205, "air density"),
+    ("nu_0", 1e-6, "water kin viscosity"),
+    ("nu_1", 1.5e-5, "air kin viscosity"),
+    ('g',np.array([0.0, -9.8, 0.0]),'Gravitational acceleration'),    
+    # sediment parameters
+    ('cSed', 0.60,'Initial sediment concentration'),
+    ('rho_s',2600 ,'sediment material density'),
+    ('alphaSed', 150.,'laminar drag coefficient'),
+    ('betaSed', 1.72,'turbulent drag coefficient'),
+    ('grain',0.0025, 'Grain size'),
+    ('packFraction',0.2,'threshold for loose / packed sediment'),
+    ('packMargin',0.01,'transition margin for loose / packed sediment'),
+    ('maxFraction',0.635,'fraction at max  sediment packing'),
+    ('frFraction',0.57,'fraction where contact stresses kick in'),
+    ('sigmaC',0.57,'Schmidt coefficient for turbulent diffusion'),
+    ('C3e',1.2,'Dissipation coefficient '),
+    ('C4e',1.2,'Dissipation coefficient'),
+    ('eR', 0.8, 'Collision stress coefficient (module not functional)'),
+    ('fContact', 0.05,'Contact stress coefficient'),
+    ('mContact', 3.0,'Contact stress coefficient'),
+    ('nContact', 5.0,'Contact stress coefficient'),
+    ('angFriction', pi/6., 'Angle of friction'),
+    ('vos_limiter', 0.6, 'Weak limiter for vos'),
+    ('mu_fr_limiter', 1e-3,'Hard limiter for contact stress friction coeff'),
+     # numerical options
+    ("he", 0.02,"element size"),
+    ("sedimentDynamics", True, "Enable sediment dynamics module"),
+    ("cfl", 0.25 ,"Target cfl"),
+    ("duration", 5.0 ,"Duration of the simulation"),
+    ("PSTAB", 1.0, "Affects subgrid error"),
+    ("res", 1.0e-8, "Residual tolerance"),
+    ("epsFact_density", 3.0, "Control width of water/air transition zone"),
+    ("epsFact_consrv_diffusion", 1.0, "Affects smoothing diffusion in mass conservation"),
+    ("useRANS", False, "Switch ON turbulence models: 0-None, 1-K-Epsilon, 2-K-Omega1998, 3-K-Omega1988"),
+    ("vos_SC",0.9,"vos shock capturing"),
+    # ns_closure: 1-classic smagorinsky, 2-dynamic smagorinsky, 3-k-epsilon, 4-k-omega
+    ("sigma_k", 1.0, "sigma_k coefficient for the turbulence model"),
+    ("sigma_e", 1.0, "sigma_e coefficient for the turbulence model"),
+    ("Cmu", 0.09, "Cmu coefficient for the turbulence model"),
+    ])
+
+# SO Models
+
+VOS_model = 0
+VOF_model = 1
+LS_model = 2
+RD_model = 3
+MCORR_model =4
+SED_model =5
+V_model =6
+DP_model = 7
+P_model = 8
+
+
+if opts.useRANS:
+    K_model = 9
+    EPS_model = 10
+    PI_model = 11
+else:
+    K_model = None
+    EPS_model = None   
+    PI_model = 9
+
+# Domain dimensions
+
+nd = 2
+
+# ----- Sediment stress ----- #
+
+sedClosure = HsuSedStress(aDarcy =  opts.alphaSed,
+                          betaForch =  opts.betaSed,
+                          grain =  opts.grain,
+                          packFraction =  opts.packFraction,
+                          packMargin =  opts.packMargin,
+                          maxFraction =  opts.maxFraction,
+                          frFraction =  opts.frFraction,
+                          sigmaC =  opts.sigmaC,
+                          C3e =  opts.C3e,
+                          C4e =  opts.C4e,
+                          eR =  opts.eR,
+                          fContact =  opts.fContact,
+                          mContact =  opts.mContact,
+                          nContact =  opts.nContact,
+                          angFriction =  opts.angFriction,
+                          vos_limiter = opts.vos_limiter,
+                          mu_fr_limiter = opts.mu_fr_limiter,
+                          )
+
+# ----- DOMAIN ----- #
+
+domain = Domain.PlanarStraightLineGraphDomain()
+
+
+# ----- Phisical constants ----- #
+  
+# Water
+rho_0 = opts.rho_0
+nu_0 = opts.nu_0
+
+# Air
+rho_1 = opts.rho_1
+nu_1 = opts.nu_1
+
+# Sediment
+
+rho_s = opts.rho_s
+nu_s = 1000000
+dragAlpha = 0.0
+
+# Surface tension
+sigma_01 = 0.0
+
+# Gravity
+g = opts.g
+gamma_0 = abs(g[1])*rho_0
+
+# Initial condition
+waterLine_x = opts.waterLine_x
+waterLine_z = opts.waterLine_z
+sediment_level = opts.sediment_level
+sediment_bottom = opts.sediment_bottom
+waterLevel = waterLine_z
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Domain and mesh
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+##TANK
+tank_dim = L = (opts.Lx, opts.Ly)
+he = opts.he
+dim = dimx, dimy = L
+coords = [ dimx/2., dimy/2. ]
+### CYLINDER #####
+cylinder_pos = np.array([opts.cylinder_pos_x, opts.cylinder_pos_y, 0.])
+cylinder_radius = opts.cylinder_radius
+if opts.circle2D:
+    circle = st.Circle(domain=domain, radius=cylinder_radius, coords=(cylinder_pos[0],cylinder_pos[1]), barycenter=(cylinder_pos[0],cylinder_pos[1]), nPoints=28)
+
+    circle2D = bd.RigidBody(shape=circle)
+    free_x = (0.0,0.0,0.0)
+    free_r = (0.0,0.0,0.0)
+    circle2D.setConstraints(free_x=free_x,free_r=free_r)
+    circle2D.setNumericalScheme(None)
+    circle2D.setRecordValues(filename='circle2D',all_values=True)
+
+boundaryOrientations = {'y-': np.array([0., -1.,0.]),
+                        'x+': np.array([+1, 0.,0.]),
+                        'y+': np.array([0., +1.,0.]),
+                        'x-': np.array([-1., 0.,0.]),
+                        'sponge': None,
+                        'circle': None,
+                        'hole_x-': np.array([-1., 0.,0.]),
+                        'hole_x+': np.array([+1., 0.,0.]),
+                        'hole_y-': np.array([0., -1.,0.]),
+
+
+                           }
+boundaryTags = {'y-': 1,
+                    'x+': 2,
+                    'y+': 3,
+                    'x-': 4,
+                    'sponge': 5,
+                    'circle':6,
+                    'hole_x-':7,
+                    'hole_x+':8,
+                    'hole_y-':9,
+                       }
+
+
+
+vertices=[[0.0, 0.0  ],#0
+          [opts.xHole/2,  0.],#1
+          [opts.xHole,  0.],#2
+          [opts.xHole,  -opts.dHole],#3
+          [opts.xHole+opts.wHole,  -opts.dHole],#4
+          [opts.xHole+opts.wHole,  0.],#5
+          [opts.xHole+opts.wHole+opts.xHole/2,  0.],#6
+          [tank_dim[0],0.],#7
+          [tank_dim[0],tank_dim[1]], #8
+          [opts.xHole+opts.wHole+opts.xHole/2, tank_dim[1]], #9
+          [opts.xHole/2, tank_dim[1]], #10
+          [0.0, tank_dim[1]], #11
+              ]
+
+vertexFlags=np.array([1, 1, 1,
+                          9, 9,
+                          1, 1, 1,
+                          3, 3, 3, 3,
+                          ])
+segments=[[0,1],
+          [1,2],
+          
+          [2,3],
+          [3,4],
+          [4,5],
+          
+          [5,6],
+          [6,7],
+          
+          [7,8],
+
+          [8,9],
+          [9,10],
+          [10,11],
+          
+          [11,0],
+          
+          [1,10],
+          [6,9],
+           ]
+
+segmentFlags=np.array([ 1, 1, 
+                        7, 9, 8,
+                        1, 1,
+                        2,
+                        3, 3, 3, 
+                        4,
+                        5, 5,
+                        ])
+
+
+regions = [ [ 0.000001 , 0.50*tank_dim[1] ],
+            [ opts.xHole+opts.wHole/2 , 0.50*tank_dim[1] ],
+            [ 0.9999*tank_dim[0] , 0.50*tank_dim[1] ] ]
+
+regionFlags=np.array([1, 2, 3])
+
+
+
+tank = st.CustomShape(domain, vertices=vertices, vertexFlags=vertexFlags,
+                      segments=segments, segmentFlags=segmentFlags,
+                      regions=regions, regionFlags=regionFlags,
+                      boundaryTags=boundaryTags, boundaryOrientations=boundaryOrientations)
+    
+
+
+
+#############################################################################################################################################################################################################################################################################################################################################################################################
+# ----- BOUNDARY CONDITIONS ----- #
+#############################################################################################################################################################################################################################################################################################################################################################################################
+steady_current = wt.SteadyCurrent(U=np.array([opts.U,0.,0.]),mwl=waterLevel,rampTime=0.1)
+tank.BC['y-'].setFreeSlip()
+tank.BC['x-'].setUnsteadyTwoPhaseVelocityInlet(wave=steady_current, smoothing = 3*he, vert_axis=1)
+tank.BC['y+'].setAtmosphere(orientation=np.array([0,1,0]))
+tank.BC['x+'].setFreeSlip()
+#tank.BC['y+'].setFreeSlip()
+
+tank.BC['x+'].setHydrostaticPressureOutletWithDepth_stressFree(seaLevel=1e10,
+                                                               rhoUp=rho_1,
+                                                               rhoDown=rho_0,
+                                                               nuUp=nu_1,
+                                                               nuDown=nu_0,
+                                                               g=g,
+                                                               refLevel=opts.Ly,
+                                                               smoothing=opts.epsFact_density*opts.he)
+
+if opts.circle2D:
+    
+    for bc in circle.BC_list:
+        if opts.circleBC == 'FreeSlip':
+            bc.setFreeSlip()
+        if opts.circleBC == 'NoSlip':
+            bc.setNoSlip()
+
+tank.BC['hole_x+'].setFreeSlip()
+
+
+tank.BC['hole_x-'].setFreeSlip()
+
+
+tank.BC['hole_y-'].setFreeSlip()
+
+
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Turbulence
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+
+if opts.useRANS:
+    kInflow = 1e-6
+    dissipationInflow = 1e-6
+    tank.BC['x-'].setTurbulentZeroGradient()
+    tank.BC['x+'].setTurbulentZeroGradient()
+    tank.BC['y-'].setTurbulentZeroGradient()
+    tank.BC['y+'].setTurbulentZeroGradient()
+
+
+######################################################################################################################################################################################################################
+# Gauges and probes #
+######################################################################################################################################################################################################################
+
+T=opts.duration
+PG = []
+gauge_dy=0.01
+tank_dim_y=dimy
+nprobes=int(tank_dim_y/gauge_dy)+1
+probes=np.linspace(0., tank_dim_y, nprobes)
+for i in probes:
+    PG.append((dimx/2., i, 0.),)
+v_output = ga.PointGauges(gauges=((('u',), PG),
+                                  (('v',), PG),),
+                          activeTime = (0., T),
+                          sampleRate=0.,
+                          fileName='fluidVelocityGauges.csv')
+vs_output = ga.PointGauges(gauges=((('us',),PG), 
+                                   (('vs',),PG),),
+                          activeTime = (0., T),
+                          sampleRate=0.,
+                          fileName='solidVelocityGauges.csv')
+vos_output = ga.PointGauges(gauges=((('vos',),PG),),
+                          activeTime = (0., T),
+                          sampleRate=0.,
+                          fileName='solidFractionGauges.csv')
+
+
+######################################################################################################################################################################################################################
+# Numerical Options and other parameters #
+######################################################################################################################################################################################################################
+ 
+domain.MeshOptions.he = he
+
+from math import *
+from proteus import MeshTools, AuxiliaryVariables
+import numpy
+import proteus.MeshTools
+from proteus import Domain
+from proteus.Profiling import logEvent
+from proteus.default_n import *
+from proteus.ctransportCoefficients import smoothedHeaviside
+from proteus.ctransportCoefficients import smoothedHeaviside_integral
+
+st.assembleDomain(domain)
+
+
+#----------------------------------------------------
+# Time stepping and velocity
+#----------------------------------------------------
+
+T=opts.duration
+weak_bc_penalty_constant = 10.0/nu_0 #100
+dt_fixed = opts.dtout
+dt_init = min(0.1*dt_fixed,0.001)
+nDTout= int(round(T/dt_fixed))
+runCFL = opts.cfl
+
+sedimentDynamics=opts.sedimentDynamics
+
+#----------------------------------------------------
+#  Discretization -- input options
+#----------------------------------------------------
+
+genMesh = True
+movingDomain = False
+applyRedistancing = True
+useOldPETSc = False
+useSuperlu = False
+timeDiscretization = 'be'#'vbdf'#'vbdf'  # 'vbdf', 'be', 'flcbdf'
+spaceOrder = 1
+pspaceOrder = 1
+useHex = False
+useRBLES = 0.0
+useMetrics = 1.0
+applyCorrection = True
+useVF = 1.0
+useOnlyVF = False
+useRANS = opts.useRANS  # 0 -- None
+                        # 1 -- K-Epsilon
+                        # 2 -- K-Omega
+
+
+KILL_PRESSURE_TERM = False
+fixNullSpace_PresInc = True
+INTEGRATE_BY_PARTS_DIV_U_PresInc = True
+CORRECT_VELOCITY = True
+STABILIZATION_TYPE = 0 #0: SUPG, 1: EV via weak residual, 2: EV via strong residual
+
+# Input checks
+if spaceOrder not in [1, 2]:
+    print "INVALID: spaceOrder" + spaceOrder
+    sys.exit()
+
+if useRBLES not in [0.0, 1.0]:
+    print "INVALID: useRBLES" + useRBLES
+    sys.exit()
+
+if useMetrics not in [0.0, 1.0]:
+    print "INVALID: useMetrics"
+    sys.exit()
+
+#  Discretization
+nd = tank.nd
+
+if spaceOrder == 1:
+    hFactor = 1.0
+    if useHex:
+        basis = C0_AffineLinearOnCubeWithNodalBasis
+        elementQuadrature = CubeGaussQuadrature(nd, 2)
+        elementBoundaryQuadrature = CubeGaussQuadrature(nd - 1, 2)
+    else:
+        basis = C0_AffineLinearOnSimplexWithNodalBasis
+        elementQuadrature = SimplexGaussQuadrature(nd, 3)
+        elementBoundaryQuadrature = SimplexGaussQuadrature(nd - 1, 3)
+elif spaceOrder == 2:
+    hFactor = 0.5
+    if useHex:
+        basis = C0_AffineLagrangeOnCubeWithNodalBasis
+        elementQuadrature = CubeGaussQuadrature(nd, 4)
+        elementBoundaryQuadrature = CubeGaussQuadrature(nd - 1, 4)
+    else:
+        basis = C0_AffineQuadraticOnSimplexWithNodalBasis
+        elementQuadrature = SimplexGaussQuadrature(nd, 4)
+        elementBoundaryQuadrature = SimplexGaussQuadrature(nd - 1, 4)
+
+if pspaceOrder == 1:
+    if useHex:
+        pbasis = C0_AffineLinearOnCubeWithNodalBasis
+    else:
+        pbasis = C0_AffineLinearOnSimplexWithNodalBasis
+elif pspaceOrder == 2:
+    if useHex:
+        pbasis = C0_AffineLagrangeOnCubeWithNodalBasis
+    else:
+        pbasis = C0_AffineQuadraticOnSimplexWithNodalBasis
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Numerical parameters
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+ns_forceStrongDirichlet = False
+ns_sed_forceStrongDirichlet = False
+backgroundDiffusionFactor=0.01
+
+if useMetrics:
+    ns_shockCapturingFactor = 0.5
+    ns_lag_shockCapturing = True
+    ns_lag_subgridError = True
+    ns_sed_shockCapturingFactor = 0.5
+    ns_sed_lag_shockCapturing = True
+    ns_sed_lag_subgridError = True
+    ls_shockCapturingFactor = 0.5
+    ls_lag_shockCapturing = True
+    ls_sc_uref = 1.0
+    ls_sc_beta = 1.0
+    vof_shockCapturingFactor = 0.5
+    vof_lag_shockCapturing = True
+    vof_sc_uref = 1.0
+    vof_sc_beta = 1.0
+    vos_shockCapturingFactor =  opts.vos_SC # <------------------------------------- 
+    vos_lag_shockCapturing = True
+    vos_sc_uref = 1.0
+    vos_sc_beta = 1.0
+    rd_shockCapturingFactor = 0.5
+    rd_lag_shockCapturing = False
+    epsFact_vos =opts.epsFact_density
+    epsFact_density = opts.epsFact_density # 1.5
+    epsFact_viscosity = epsFact_curvature = epsFact_vof = epsFact_consrv_heaviside = epsFact_consrv_dirac = epsFact_density
+    epsFact_redistance = 0.33
+    epsFact_consrv_diffusion = opts.epsFact_consrv_diffusion # 0.1
+    redist_Newton = True
+    kappa_shockCapturingFactor = 0.25
+    kappa_lag_shockCapturing = True  #False
+    kappa_sc_uref = 1.0
+    kappa_sc_beta = 1.0
+    dissipation_shockCapturingFactor = 0.25
+    dissipation_lag_shockCapturing = True  #False
+    dissipation_sc_uref = 1.0
+    dissipation_sc_beta = 1.0
+else:
+    ns_shockCapturingFactor = 0.9
+    ns_lag_shockCapturing = True
+    ns_lag_subgridError = True
+    ns_sed_shockCapturingFactor = 0.9
+    ns_sed_lag_shockCapturing = True
+    ns_sed_lag_subgridError = True
+    ls_shockCapturingFactor = 0.9
+    ls_lag_shockCapturing = True
+    ls_sc_uref = 1.0
+    ls_sc_beta = 1.0
+    vof_shockCapturingFactor = 0.9
+    vof_lag_shockCapturing = True
+    vof_sc_uref = 1.0
+    vof_sc_beta = 1.0
+    vos_shockCapturingFactor = 5.
+    vos_lag_shockCapturing = True
+    vos_sc_uref = 1.0
+    vos_sc_beta = 1.0
+    rd_shockCapturingFactor = 0.9
+    rd_lag_shockCapturing = False
+    epsFact_density = opts.epsFact_density # 1.5
+    epsFact_viscosity = epsFact_curvature = epsFact_vof = epsFact_vos = epsFact_consrv_heaviside = epsFact_consrv_dirac = epsFact_density
+    epsFact_redistance = 0.33
+    epsFact_consrv_diffusion = opts.epsFact_consrv_diffusion # 1.0
+    redist_Newton = False
+    kappa_shockCapturingFactor = 0.9
+    kappa_lag_shockCapturing = True  #False
+    kappa_sc_uref = 1.0
+    kappa_sc_beta = 1.0
+    dissipation_shockCapturingFactor = 0.9
+    dissipation_lag_shockCapturing = True  #False
+    dissipation_sc_uref = 1.0
+    dissipation_sc_beta = 1.0
+
+ns_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+ns_sed_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+vof_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+vos_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+ls_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+rd_nl_atol_res =  max(opts.res, 0.005 * he)
+mcorr_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+kappa_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+dissipation_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+phi_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+pressure_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Turbulence
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+ns_closure = 0  #1-classic smagorinsky, 2-dynamic smagorinsky, 3 -- k-epsilon, 4 -- k-omega
+ns_sed_closure = 0  #1-classic smagorinsky, 2-dynamic smagorinsky, 3 -- k-epsilon, 4 -- k-omega
+if useRANS == 1:
+    ns_closure = 3
+elif useRANS == 2:
+    ns_closure == 4
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Functions for model variables - Initial conditions
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+def signedDistance(x):
+    phi_z = x[1] - waterLine_z
+    return phi_z
+
+def vos_signedDistance(x):
+    phi_z1 = x[1] - sediment_level
+    phi_z2 = sediment_bottom - x[1]
+    if abs(phi_z1) < abs(phi_z2):
+        phi_z = phi_z1
+    else:
+        phi_z = phi_z2
+    return phi_z
+
+class Suspension_class:
+    def __init__(self):
+        pass
+    def uOfXT(self, x, t=0):
+        phi = vos_signedDistance(x)
+        smoothing = (epsFact_consrv_heaviside)*he/2.
+        Heav = smoothedHeaviside(smoothing, phi)      
+        if phi <= -smoothing:
+            return opts.cSed
+        elif -smoothing < phi < smoothing:
+            return opts.cSed * (1.-Heav)            
+        else:
+            return 1e-10    
+
+Suspension = Suspension_class()
+
+vos_function = Suspension.uOfXT

--- a/2d/sediment/sediment_erosion/tank_so.py
+++ b/2d/sediment/sediment_erosion/tank_so.py
@@ -1,0 +1,86 @@
+from proteus import StepControl
+"""
+Split operator module for two-phase flow
+"""
+
+from proteus.default_so import *
+import os
+from proteus import Context
+
+# Create context from main module
+name_so = os.path.basename(__file__)
+if '_so.py' in name_so[-6:]:
+    name = name_so[:-6]
+elif '_so.pyc' in name_so[-7:]:
+    name = name_so[:-7]
+else:
+    raise NameError, 'Split operator module must end with "_so.py"'
+
+#try:
+case = __import__(name)
+Context.setFromModule(case)
+ct = Context.get()
+#except ImportError:
+#    raise ImportError, str(name) + '.py not found'
+
+from proteus import BoundaryConditions
+for BC in ct.domain.bc:
+    BC.getContext()
+
+from proteus.SplitOperator import Sequential_FixedStep_Simple, defaultSystem
+if ct.sedimentDynamics:
+    pnList = [("vos_p",               "vos_n"),#0
+              ("vof_p",               "vof_n"),#1
+              ("ls_p",                "ls_n"),#2
+              ("redist_p",            "redist_n"),#3
+              ("ls_consrv_p",         "ls_consrv_n"),#4
+              ("threep_navier_stokes_sed_p", "threep_navier_stokes_sed_n"),#5
+              ("twp_navier_stokes_p", "twp_navier_stokes_n"),#6
+              ("pressureincrement_p", "pressureincrement_n"),#7
+              ("pressure_p", "pressure_n")]#8
+    
+else:
+    pnList = [("vof_p",               "vof_n"),#0
+              ("ls_p",                "ls_n"),#1
+              ("redist_p",            "redist_n"),#2
+              ("ls_consrv_p",         "ls_consrv_n"),#3
+              ("twp_navier_stokes_p", "twp_navier_stokes_n"),#4
+              ("pressureincrement_p", "pressureincrement_n"),#5
+              ("pressure_p", "pressure_n")]#6
+
+if ct.useRANS > 0:
+    pnList.append(("kappa_p",
+                   "kappa_n"))#7 or #9
+    pnList.append(("dissipation_p",
+                   "dissipation_n"))#8 or #10
+
+pnList.append(("pressureInitial_p",
+                   "pressureInitial_n"))#7 or #9
+
+        
+              
+name = "tank"
+
+#modelSpinUpList = [ct.VOF_model, ct.LS_model, ct.V_model, ct.PINIT_model]
+modelSpinUpList = [ct.PI_model]
+
+class Sequential_MinAdaptiveModelStepPS(Sequential_MinAdaptiveModelStep):
+    def __init__(self,modelList,system=defaultSystem,stepExact=True):
+        Sequential_MinAdaptiveModelStep.__init__(self,modelList,system,stepExact)
+        self.modelList = modelList[:len(pnList)-1]
+
+#class Sequential_MinAdaptiveModelStepPS(Sequential_FixedStep):
+#    def __init__(self,modelList,system=defaultSystem,stepExact=True):
+#        Sequential_FixedStep.__init__(self,modelList,system,stepExact)
+#        self.modelList = modelList[:len(pnList)-1]
+#dt_system_fixed = ct.dt_fixed
+
+systemStepControllerType = Sequential_MinAdaptiveModelStepPS
+
+needEBQ_GLOBAL = False
+needEBQ = False
+
+tnList = [0.0,ct.dt_init]+[ct.dt_init+i*ct.dt_fixed for i in range(1,ct.nDTout+1)]
+
+info = open("TimeList.txt","w")
+#archiveFlag = ArchiveFlags.EVERY_SEQUENCE_STEP

--- a/2d/sediment/sediment_erosion/threep_navier_stokes_sed_n.py
+++ b/2d/sediment/sediment_erosion/threep_navier_stokes_sed_n.py
@@ -1,0 +1,72 @@
+from proteus import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+from threep_navier_stokes_sed_p import *
+from tank import *
+
+if timeDiscretization=='vbdf':
+    timeIntegration = VBDF
+    timeOrder=2
+    stepController  = Min_dt_cfl_controller
+elif timeDiscretization=='flcbdf':
+    timeIntegration = FLCBDF
+    #stepController = FLCBDF_controller_sys
+    stepController  = Min_dt_cfl_controller
+    time_tol = 10.0*ns_sed_nl_atol_res
+    atol_u = {0:time_tol,1:time_tol}
+    rtol_u = {0:time_tol,1:time_tol}
+else:
+    timeIntegration = BackwardEuler_cfl
+    stepController  = Min_dt_cfl_controller
+
+femSpaces = {0:basis,
+	     1:basis}
+
+massLumping       = False
+numericalFluxType = None
+conservativeFlux  = None
+
+numericalFluxType = RANS3PSed.NumericalFlux
+subgridError = RANS3PSed.SubgridError(coefficients,nd,lag=ns_sed_lag_subgridError,hFactor=hFactor)
+shockCapturing = RANS3PSed.ShockCapturing(coefficients,nd,ns_sed_shockCapturingFactor,lag=ns_sed_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+
+linearSmoother    = None
+
+matrix = SparseMatrix
+
+if useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'rans3p_sed_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest             = 'r-true'
+
+tolFac = 0.0
+linTolFac = 0.01
+l_atol_res = 0.01*ns_sed_nl_atol_res
+nl_atol_res = ns_sed_nl_atol_res
+useEisenstatWalker = False
+maxNonlinearIts = 50
+maxLineSearches = 0
+conservativeFlux = {0:'point-eval'}
+#conservativeFlux = {0:'pwl-bdm-opt'}
+#auxiliaryVariables=[pointGauges,lineGauges]
+auxiliaryVariables = ct.domain.auxiliaryVariables['thp']+[ct.vs_output]

--- a/2d/sediment/sediment_erosion/threep_navier_stokes_sed_p.py
+++ b/2d/sediment/sediment_erosion/threep_navier_stokes_sed_p.py
@@ -1,0 +1,81 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import RANS3PSed
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = RANS3PSed.LevelModel
+
+
+coefficients = RANS3PSed.Coefficients(epsFact=epsFact_viscosity,
+                                      sigma=0.0,
+                                      rho_0 = rho_0,
+                                      nu_0 = nu_0, 
+                                      rho_1 = rho_1,
+                                      nu_1 = nu_1,
+                                      rho_s = rho_s,
+                                      g=g,
+                                      nd=nd,
+                                      ME_model=ct.SED_model,
+                                      PRESSURE_model=ct.P_model,
+                                      FLUID_model=ct.V_model,
+                                      VOS_model=ct.VOS_model,
+                                      VOF_model=ct.VOF_model,
+                                      LS_model=ct.LS_model,
+                                      Closure_0_model=ct.K_model,
+                                      Closure_1_model=ct.EPS_model,
+                                      epsFact_density=epsFact_density,
+                                      stokes=False,
+                                      useVF=True,
+                                      useRBLES=useRBLES,
+                                      useMetrics=useMetrics,
+                                      eb_adjoint_sigma=1.0,
+                                      eb_penalty_constant=weak_bc_penalty_constant,
+                                      forceStrongDirichlet=ns_forceStrongDirichlet,
+                                      turbulenceClosureModel=ns_closure,
+                                      movingDomain=movingDomain,
+                                      dragAlpha=dragAlpha,
+                                      PSTAB=ct.opts.PSTAB,
+                                    aDarcy = sedClosure.aDarcy,
+                                    betaForch = sedClosure.betaForch,
+                                    grain = sedClosure.grain,
+                                    packFraction = sedClosure.packFraction,
+                                    maxFraction = sedClosure.maxFraction,
+                                    frFraction = sedClosure.frFraction,
+                                    sigmaC = sedClosure.sigmaC,
+                                    C3e = sedClosure.C3e,
+                                    C4e = sedClosure.C4e,
+                                    eR = sedClosure.eR,
+                                    fContact = sedClosure.fContact,
+                                    mContact = sedClosure.mContact,
+                                    nContact = sedClosure.nContact,
+                                    angFriction = sedClosure.angFriction,
+                                    vos_function = ct.vos_function,
+                                    staticSediment = False,
+                                    vos_limiter = ct.sedClosure.vos_limiter,
+                                    mu_fr_limiter = ct.sedClosure.mu_fr_limiter)
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].us_dirichlet.init_cython(),
+                       1: lambda x, flag: domain.bc[flag].vs_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].us_advective.init_cython(),
+                                   1: lambda x, flag: domain.bc[flag].vs_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {0: lambda x, flag: domain.bc[flag].us_diffusive.init_cython()},
+                                   1: {1: lambda x, flag: domain.bc[flag].vs_diffusive.init_cython()}}
+
+if nd == 3:
+    dirichletConditions[2] = lambda x, flag: domain.bc[flag].ws_dirichlet.init_cython()
+    advectiveFluxBoundaryConditions[2] = lambda x, flag: domain.bc[flag].ws_advective.init_cython()
+    diffusiveFluxBoundaryConditions[2] = {2: lambda x, flag: domain.bc[flag].ws_diffusive.init_cython()}
+
+class AtRest:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+initialConditions = {0:AtRest(),
+                     1:AtRest()}

--- a/2d/sediment/sediment_erosion/twp_navier_stokes_n.py
+++ b/2d/sediment/sediment_erosion/twp_navier_stokes_n.py
@@ -1,0 +1,74 @@
+from proteus import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+from twp_navier_stokes_p import *
+from tank import *
+
+if timeDiscretization=='vbdf':
+    timeIntegration = VBDF
+    timeOrder=2
+    stepController  = Min_dt_cfl_controller
+elif timeDiscretization=='flcbdf':
+    timeIntegration = FLCBDF
+    #stepController = FLCBDF_controller_sys
+    stepController  = Min_dt_cfl_controller
+    time_tol = 10.0*ns_nl_atol_res
+    atol_u = {0:time_tol,1:time_tol}
+    rtol_u = {0:time_tol,1:time_tol}
+else:
+    timeIntegration = BackwardEuler_cfl
+    stepController  = Min_dt_cfl_controller
+
+femSpaces = {0:basis,
+	     1:basis}
+#femSpaces = {0:C0_AffineQuadraticOnSimplexWithNodalBasis,
+#             1:C0_AffineQuadraticOnSimplexWithNodalBasis}
+
+massLumping       = False
+numericalFluxType = None
+conservativeFlux  = None
+
+numericalFluxType = RANS3PF.NumericalFlux
+subgridError = RANS3PF.SubgridError(coefficients,nd,lag=ns_lag_subgridError,hFactor=hFactor)
+shockCapturing = RANS3PF.ShockCapturing(coefficients,nd,ns_shockCapturingFactor,lag=ns_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+
+linearSmoother    = None #SimpleNavierStokes2D
+
+matrix = SparseMatrix
+
+if useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'rans2p_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest             = 'r-true'
+
+tolFac = 0.0
+linTolFac = 0.01
+l_atol_res = 0.01*ns_nl_atol_res
+nl_atol_res = ns_nl_atol_res
+useEisenstatWalker = False
+maxNonlinearIts = 50
+maxLineSearches = 0
+conservativeFlux = {0:'point-eval'}
+#conservativeFlux = {0:'pwl-bdm-opt'}
+#auxiliaryVariables=[pointGauges,lineGauges]
+auxiliaryVariables = ct.domain.auxiliaryVariables['twp']+[ct.v_output]

--- a/2d/sediment/sediment_erosion/twp_navier_stokes_p.py
+++ b/2d/sediment/sediment_erosion/twp_navier_stokes_p.py
@@ -1,0 +1,129 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import RANS3PF
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = RANS3PF.LevelModel
+
+coefficients = RANS3PF.Coefficients(epsFact=epsFact_viscosity,
+                                    sigma=0.0,
+                                    rho_0 = rho_0,
+                                    nu_0 = nu_0,
+                                    rho_1 = rho_1,
+                                    nu_1 = nu_1,
+                                    g=g,
+                                    nd=nd,
+                                    ME_model=ct.V_model,
+                                    PRESSURE_model=ct.P_model,
+                                    SED_model=ct.SED_model,
+                                    VOF_model=ct.VOF_model,
+                                    VOS_model=ct.VOS_model,
+                                    LS_model=ct.LS_model,
+                                    Closure_0_model=ct.K_model,
+                                    Closure_1_model=ct.EPS_model,
+                                    epsFact_density=epsFact_density,
+                                    stokes=False,
+                                    useVF=useVF,
+                                    useRBLES=useRBLES,
+                                    useMetrics=useMetrics,
+                                    eb_adjoint_sigma=1.0,
+                                    eb_penalty_constant=weak_bc_penalty_constant,
+                                    forceStrongDirichlet=ns_forceStrongDirichlet,
+                                    turbulenceClosureModel=ns_closure,
+                                    movingDomain=movingDomain,
+                                    dragAlpha=dragAlpha,
+                                    PSTAB=ct.opts.PSTAB,
+                                    aDarcy = sedClosure.aDarcy,
+                                    betaForch = sedClosure.betaForch,
+                                    grain = sedClosure.grain,
+                                    packFraction = sedClosure.packFraction,
+                                    maxFraction = sedClosure.maxFraction,
+                                    frFraction = sedClosure.frFraction,
+                                    sigmaC = sedClosure.sigmaC,
+                                    C3e = sedClosure.C3e,
+                                    C4e = sedClosure.C4e,
+                                    eR = sedClosure.eR,
+                                    fContact = sedClosure.fContact,
+                                    mContact = sedClosure.mContact,
+                                    nContact = sedClosure.nContact,
+                                    angFriction = sedClosure.angFriction,
+                                    vos_function = ct.vos_function,
+                                    vos_limiter = ct.sedClosure.vos_limiter,
+                                    mu_fr_limiter = ct.sedClosure.mu_fr_limiter,
+                                    )
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].u_dirichlet.init_cython(),
+                       1: lambda x, flag: domain.bc[flag].v_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].u_advective.init_cython(),
+                                   1: lambda x, flag: domain.bc[flag].v_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {0: lambda x, flag: domain.bc[flag].u_diffusive.init_cython()},
+                                   1: {1: lambda x, flag: domain.bc[flag].v_diffusive.init_cython()}}
+
+if nd == 3:
+    dirichletConditions[2] = lambda x, flag: domain.bc[flag].w_dirichlet.init_cython()
+    advectiveFluxBoundaryConditions[2] = lambda x, flag: domain.bc[flag].w_advective.init_cython()
+    diffusiveFluxBoundaryConditions[2] = {2: lambda x, flag: domain.bc[flag].w_diffusive.init_cython()}
+
+class AtRest:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+
+smoothing = 3*he
+
+
+class U_IC:
+
+
+    def uOfXT(self,x,t):
+        if ct.signedDistance(x) <= -0.28:
+            H = 1
+            speed = 0
+        elif -0.278 < ct.signedDistance(x) < -0.28 + smoothing:
+            H = 1-(smoothedHeaviside(smoothing/2. , ct.signedDistance(x)+0.28 - smoothing/2.))
+            speed = ct.opts.inflow_vel
+
+        elif  (ct.signedDistance(x) <= 0): 
+        #and ct.signedDistance(x)>= -0.27+smoothing):
+            H = 0
+            speed = ct.opts.inflow_vel
+        
+        elif 0 < ct.signedDistance(x) <= smoothing:
+            H = smoothedHeaviside(smoothing/2. , ct.signedDistance(x) - smoothing/2.)
+            speed = ct.opts.inflow_vel
+        else:
+            H = 1
+            speed = 0
+        
+        u = H * 0.0 + (1-H)*speed
+
+        return u
+
+
+class V_IC:
+    def uOfXT(self,x,t):
+                
+        v = 0.0
+
+        return v
+
+
+
+
+#if ct.opts.current:
+#    initialConditions = {0: U_IC(),
+#                         1: V_IC()}
+#
+#else:    
+#    initialConditions = {0:AtRest(),
+#                         1:AtRest()}
+
+initialConditions = {0:AtRest(),
+                     1:AtRest()}

--- a/2d/sediment/sediment_erosion/vof_n.py
+++ b/2d/sediment/sediment_erosion/vof_n.py
@@ -1,0 +1,77 @@
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import vof_p as physics
+from proteus.mprans import VOF3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+# time stepping
+runCFL = ct.runCFL
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_controller
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = VOF3P.NumericalFlux
+conservativeFlux  = None
+subgridError      = VOF3P.SubgridError(coefficients=physics.coefficients,nd=nd)
+shockCapturing    = VOF3P.ShockCapturing(physics.coefficients,nd,shockCapturingFactor=ct.vof_shockCapturingFactor,lag=ct.vof_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'vof_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'r-true'
+
+tolFac      = 0.0
+nl_atol_res = ct.vof_nl_atol_res
+
+linTolFac   = 0.0
+l_atol_res = 0.1*ct.vof_nl_atol_res
+
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+
+auxiliaryVariables = ct.domain.auxiliaryVariables['vof']

--- a/2d/sediment/sediment_erosion/vof_p.py
+++ b/2d/sediment/sediment_erosion/vof_p.py
@@ -1,0 +1,39 @@
+from proteus.default_p import *
+from proteus.ctransportCoefficients import smoothedHeaviside
+from proteus.mprans import VOF3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+LevelModelType = VOF3P.LevelModel
+
+coefficients = VOF3P.Coefficients(LS_model=ct.LS_model,
+                                  V_model=ct.V_model,
+                                  RD_model=ct.RD_model,
+                                  ME_model=ct.VOF_model,
+                                  VOS_model=ct.VOS_model,
+                                  checkMass=True,
+                                  useMetrics=ct.useMetrics,
+                                  epsFact=ct.epsFact_vof,
+                                  sc_uref=ct.vof_sc_uref,
+                                  sc_beta=ct.vof_sc_beta,
+                                  movingDomain=ct.movingDomain)
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].vof_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].vof_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {}}
+
+class VF_IC:
+    def uOfXT(self, x, t):
+        return smoothedHeaviside(ct.epsFact_consrv_heaviside*mesh.he,x[nd-1]-ct.waterLevel)
+
+initialConditions = {0: VF_IC()}

--- a/2d/sediment/sediment_erosion/vos_n.py
+++ b/2d/sediment/sediment_erosion/vos_n.py
@@ -1,0 +1,81 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import vof_p as physics
+from proteus import Context
+from proteus.mprans import VOS3P
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+# time stepping
+runCFL = ct.runCFL
+timeIntegration = VOS3P.RKEV#BackwardEuler_cfl
+stepController  = StepControl.Min_dt_controller
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = VOS3P.NumericalFlux
+conservativeFlux  = None
+subgridError      = VOS3P.SubgridError(coefficients=physics.coefficients,nd=nd)
+shockCapturing    = VOS3P.ShockCapturing(physics.coefficients,nd,shockCapturingFactor=ct.vos_shockCapturingFactor,lag=ct.vos_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.ExplicitLumpedMassMatrix
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'vos_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'r-true'
+
+tolFac      = 0.0
+nl_atol_res = ct.vos_nl_atol_res
+
+linTolFac   = 0.0
+l_atol_res = 0.1*ct.vos_nl_atol_res
+
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+
+#auxiliaryVariables = ct.domain.auxiliaryVariables['vos']
+auxiliaryVariables = ct.domain.auxiliaryVariables['vos']+[ct.vos_output]

--- a/2d/sediment/sediment_erosion/vos_p.py
+++ b/2d/sediment/sediment_erosion/vos_p.py
@@ -1,0 +1,40 @@
+from proteus import StepControl
+from proteus.default_p import *
+from proteus.ctransportCoefficients import smoothedHeaviside
+from proteus.mprans import VOS3P
+from proteus import Context
+from proteus import *
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+LevelModelType = VOS3P.LevelModel
+
+coefficients = VOS3P.Coefficients(V_model=ct.V_model,
+                                  SED_model=ct.SED_model,
+                                  ME_model=ct.VOS_model,
+                                  checkMass=False,
+                                  useMetrics=ct.useMetrics,
+                                  epsFact=ct.epsFact_vos,
+                                  sc_uref=ct.vos_sc_uref,
+                                  sc_beta=ct.vos_sc_beta,
+                                  movingDomain=ct.movingDomain,
+                                  vos_function=ct.vos_function,
+                                  global_max_u=ct.opts.vos_limiter,
+                                  STABILIZATION_TYPE=4,
+                                  LUMPED_MASS_MATRIX=True,
+                                  cE = 1.,
+                                  cK=0.
+                                  
+                                  )
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].vos_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].vos_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {}}
+
+
+initialConditions  = {0:ct.Suspension}

--- a/2d/sediment/strip_sediment/TimeSeriesPlot.py
+++ b/2d/sediment/strip_sediment/TimeSeriesPlot.py
@@ -1,0 +1,54 @@
+from proteus import StepControl
+#from scipy import *
+from pylab import *
+from numpy import *
+import collections as cll
+
+filename='pointGauge_pressure.txt'
+headerline = 0
+
+
+# Read header info 
+
+fid = open(filename,'r')
+prdata=loadtxt(fid,skiprows=headerline)
+fid.seek(0)
+D = fid.readlines()
+header = D[:headerline]
+n=len(D)
+
+a = array(zeros((int(n),5)))
+step = zeros(int(n),float)
+for i in range (int(n)):
+ a[i,:]=D[i].split()
+ step[i]=i
+
+a = array(a,dtype=float32)
+
+y = zeros(int(n),float)
+
+y[:] = a[:,2]
+
+
+
+
+
+
+#j=str(2)
+
+fig1 = figure(1)
+fig1.add_subplot(1,1,1)
+plot(step[:],y[:],"k",lw=2)
+
+##xlim(80,90)
+##ylim(-0.05,0.05)
+
+grid()
+#title('Surface elevation at $x=$' + str(probex[int(j)])+'m')
+title('Point gauge pressure evolution')
+xlabel('Step')
+ylabel('Pressure')
+
+show()
+savefig('plottrial.pdf')
+savefig('plottrial.png',dpi=100)

--- a/2d/sediment/strip_sediment/dissipation_n.py
+++ b/2d/sediment/strip_sediment/dissipation_n.py
@@ -1,0 +1,59 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import dissipation_p as physics
+from proteus import Context
+from proteus.mprans import Dissipation
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+triangleOptions = mesh.triangleOptions
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_cfl_controller
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = Dissipation.NumericalFlux
+conservativeFlux  = None
+subgridError      = Dissipation.SubgridError(coefficients=physics.coefficients,nd=ct.nd)
+shockCapturing    = Dissipation.ShockCapturing(physics.coefficients,ct.nd,shockCapturingFactor=ct.dissipation_shockCapturingFactor,
+                                         lag=ct.dissipation_lag_shockCapturing)
+
+fullNewtonFlag  = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+#printNonlinearSolverInfo = True
+matrix = SparseMatrix
+if not ct.useOldPETSc and not ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+else:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'dissipation_'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'rits'
+
+tolFac = 0.0
+linTolFac =0.0
+l_atol_res = 0.001*ct.dissipation_nl_atol_res
+nl_atol_res = ct.dissipation_nl_atol_res
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+

--- a/2d/sediment/strip_sediment/dissipation_p.py
+++ b/2d/sediment/strip_sediment/dissipation_p.py
@@ -1,0 +1,53 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import Dissipation
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = Dissipation.LevelModel
+
+dissipation_model_flag = 1
+if ct.useRANS >= 2:
+    dissipation_model_flag=2
+coefficients = Dissipation.Coefficients(V_model=ct.V_model,
+                                        ME_model=ct.EPS_model,
+                                        LS_model=ct.LS_model,
+                                        RD_model=ct.RD_model,
+                                        kappa_model=ct.K_model,
+                                        SED_model=ct.SED_model,
+                                        dissipation_model_flag=dissipation_model_flag+int(ct.movingDomain),#1 -- K-epsilon, 2 -- K-omega
+                                        useMetrics=useMetrics,
+                                        rho_0=rho_0,
+                                        nu_0=nu_0,
+                                        rho_1=rho_1,
+                                        nu_1=nu_1,
+                                        g=g,
+                                        c_mu=ct.opts.Cmu,sigma_e=ct.opts.sigma_e,
+                                        nd = ct.nd,
+                                        sc_uref=dissipation_sc_uref,
+                                        sc_beta=dissipation_sc_beta,
+                                        closure = ct.sedClosure )
+
+kInflow=ct.dissipationInflow
+
+dissipationInflow=ct.dissipationInflow
+
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].dissipation_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].dissipation_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {},
+                                   1: {1: lambda x, flag: domain.bc[flag].dissipation_diffusive.init_cython()},
+                                  }
+
+ 
+class ConstantIC:
+    def __init__(self,cval=0.0):
+        self.cval=cval
+    def uOfXT(self,x,t):
+        return self.cval
+
+initialConditions  = {0:ConstantIC(cval=dissipationInflow)}

--- a/2d/sediment/strip_sediment/eddy_viscosity_view_batch.py
+++ b/2d/sediment/strip_sediment/eddy_viscosity_view_batch.py
@@ -1,0 +1,7 @@
+from proteus import StepControl
+#0 is Navier-Stokes flow model
+simFlagsList[0]['storeQuantities']= ['simulationData',"q:'eddy_viscosity'"]
+simFlagsList[0]['storeTimes']     = ['All']
+#
+start
+quit

--- a/2d/sediment/strip_sediment/kappa_n.py
+++ b/2d/sediment/strip_sediment/kappa_n.py
@@ -1,0 +1,61 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import kappa_p as physics
+from proteus import Context
+from proteus.mprans import Kappa
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+triangleOptions = mesh.triangleOptions
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_cfl_controller
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = Kappa.NumericalFlux
+conservativeFlux  = None
+subgridError      = Kappa.SubgridError(coefficients=physics.coefficients,nd=ct.nd)
+shockCapturing    = Kappa.ShockCapturing(physics.coefficients,ct.nd,shockCapturingFactor=ct.kappa_shockCapturingFactor,
+                                         lag=ct.kappa_lag_shockCapturing)
+
+fullNewtonFlag  = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+#printNonlinearSolverInfo = True
+matrix = SparseMatrix
+if not ct.useOldPETSc and not ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+else:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'kappa_'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'rits'
+
+tolFac = 0.0
+linTolFac =0.0
+l_atol_res = 0.001*ct.kappa_nl_atol_res
+nl_atol_res = ct.kappa_nl_atol_res
+useEisenstatWalker = False
+
+maxNonlinearIts = 10
+maxLineSearches = 0
+
+auxiliaryVariables = ct.domain.auxiliaryVariables['kappa']
+

--- a/2d/sediment/strip_sediment/kappa_p.py
+++ b/2d/sediment/strip_sediment/kappa_p.py
@@ -1,0 +1,50 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import Kappa
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = Kappa.LevelModel
+
+dissipation_model_flag = 1
+if ct.useRANS >= 2:
+    dissipation_model_flag=2
+
+coefficients = Kappa.Coefficients(V_model=ct.V_model,
+                                  ME_model=ct.K_model,
+                                  LS_model=ct.LS_model,
+                                  RD_model=ct.RD_model,
+                                  dissipation_model=ct.EPS_model,
+                                  SED_model=ct.SED_model,
+                                  dissipation_model_flag=dissipation_model_flag+int(ct.movingDomain),#1 -- K-epsilon, 2 -- K-omega
+                                  useMetrics=useMetrics,
+                                  rho_0=rho_0,nu_0=nu_0,
+                                  rho_1=rho_1,nu_1=nu_1,
+                                  g=g,
+                                  nd = ct.nd,
+                                  c_mu=ct.opts.Cmu,sigma_k=ct.opts.sigma_k, 
+                                  sc_uref=kappa_sc_uref,
+                                  sc_beta=kappa_sc_beta,
+                                  closure = ct.sedClosure)
+
+kInflow=ct.kInflow
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].k_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].k_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {},
+                                   1: {1: lambda x, flag: domain.bc[flag].k_diffusive.init_cython()},
+                                  }
+
+
+class ConstantIC:
+    def __init__(self,cval=0.0):
+        self.cval=cval
+    def uOfXT(self,x,t):
+        return self.cval
+
+   
+initialConditions  = {0:ConstantIC(cval=kInflow)}

--- a/2d/sediment/strip_sediment/ls_consrv_n.py
+++ b/2d/sediment/strip_sediment/ls_consrv_n.py
@@ -1,0 +1,78 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools,
+                     NumericalFlux)
+import ls_consrv_p as physics
+from proteus import Context
+from proteus.mprans.MCorr3P import DummyNewton
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+#time stepping
+runCFL = ct.runCFL
+timeIntegrator  = TimeIntegration.ForwardIntegrator
+timeIntegration = TimeIntegration.NoIntegration
+
+#mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0:ct.basis}
+
+subgridError      = None
+massLumping       = False
+numericalFluxType = ct.DoNothing
+conservativeFlux  = None
+shockCapturing    = None
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+#multilevelNonlinearSolver = DummyNewton
+#levelNonlinearSolver      = DummyNewton
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'mcorr_'
+nonlinearSolverConvergenceTest  = 'rits'
+levelNonlinearSolverConvergenceTest  = 'rits'
+linearSolverConvergenceTest  = 'r-true'
+
+tolFac = 0.0
+linTolFac = 0.01
+l_atol_res = 0.01*ct.mcorr_nl_atol_res
+nl_atol_res = ct.mcorr_nl_atol_res
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0

--- a/2d/sediment/strip_sediment/ls_consrv_p.py
+++ b/2d/sediment/strip_sediment/ls_consrv_p.py
@@ -1,0 +1,40 @@
+from proteus import StepControl
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import MCorr3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+
+LevelModelType = MCorr3P.LevelModel
+
+coefficients = MCorr3P.Coefficients(LS_model=ct.LS_model,
+                                    V_model=ct.V_model,
+                                    ME_model=ct.MCORR_model,
+                                    VOF_model=ct.VOF_model,
+                                    VOS_model=ct.VOS_model,
+                                    applyCorrection=ct.applyCorrection,
+                                    nd=nd,
+                                    checkMass=False,
+                                    useMetrics=ct.useMetrics,
+                                    epsFactHeaviside=ct.epsFact_consrv_heaviside,
+                                    epsFactDirac=ct.epsFact_consrv_dirac,
+                                    epsFactDiffusion=ct.epsFact_consrv_diffusion)
+
+class zero_phi:
+    def __init__(self):
+        pass
+    def uOfX(self,X):
+        return 0.0
+    def uOfXT(self,X,t):
+        return 0.0
+
+initialConditions  = {0:zero_phi()}

--- a/2d/sediment/strip_sediment/ls_n.py
+++ b/2d/sediment/strip_sediment/ls_n.py
@@ -1,0 +1,78 @@
+from proteus import StepControl
+from proteus.default_n import *
+import ls_p as physics
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+from proteus.mprans import NCLS3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+coefficients = physics.coefficients
+
+# time stepping
+runCFL = ct.runCFL
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_controller
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0: ct.basis}
+
+massLumping       = False
+conservativeFlux  = None
+numericalFluxType = NCLS3P.NumericalFlux
+subgridError      = NCLS3P.SubgridError(coefficients,nd)
+shockCapturing    = NCLS3P.ShockCapturing(coefficients,nd,shockCapturingFactor=ct.ls_shockCapturingFactor,lag=ct.ls_lag_shockCapturing)
+
+fullNewtonFlag  = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'ncls_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'r-true'
+
+tolFac = 0.0
+nl_atol_res = ct.ls_nl_atol_res
+linTolFac = 0.0
+l_atol_res = 0.1*ct.ls_nl_atol_res
+
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+
+auxiliaryVariables = ct.domain.auxiliaryVariables['ls']

--- a/2d/sediment/strip_sediment/ls_p.py
+++ b/2d/sediment/strip_sediment/ls_p.py
@@ -1,0 +1,39 @@
+from proteus import StepControl
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import NCLS3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+
+LevelModelType = NCLS3P.LevelModel
+
+coefficients = NCLS3P.Coefficients(V_model=ct.V_model,
+                                   RD_model=ct.RD_model,
+                                   ME_model=ct.LS_model,
+                                   checkMass=False,
+                                   useMetrics=ct.useMetrics,
+                                   epsFact=ct.epsFact_consrv_heaviside,
+                                   sc_uref=ct.ls_sc_uref,
+                                   sc_beta=ct.ls_sc_beta,
+                                   movingDomain=ct.movingDomain)
+
+dirichletConditions = {0: lambda x, flag: None}
+
+advectiveFluxBoundaryConditions = {}
+
+diffusiveFluxBoundaryConditions = {0: {}}
+
+class PHI_IC:
+    def uOfXT(self, x, t):
+        return x[nd-1] - ct.waterLevel
+
+initialConditions = {0: PHI_IC()}

--- a/2d/sediment/strip_sediment/pressureInitial_n.py
+++ b/2d/sediment/strip_sediment/pressureInitial_n.py
@@ -1,0 +1,54 @@
+from proteus import *
+from proteus.default_n import *
+from pressureInitial_p import *
+
+
+mesh = domain.MeshOptions
+triangleOptions = triangleOptions
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+
+femSpaces = {0:ct.pbasis}
+
+stepController=FixedStep
+
+#numericalFluxType = NumericalFlux.ConstantAdvection_Diffusion_SIPG_exterior #weak boundary conditions (upwind ?)
+matrix = LinearAlgebraTools.SparseMatrix
+
+#linearSmoother    = LinearSolvers.NavierStokesPressureCorrection # pure neumann laplacian solver
+#multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+#levelLinearSolver = LinearSolvers.KSP_petsc4py
+#linearSmoother    = None
+#multilevelLinearSolver = LinearSolvers.LU
+#levelLinearSolver      = LinearSolvers.LU
+numericalFluxType = NumericalFlux.ConstantAdvection_exterior
+#numericalFluxType = NumericalFlux
+
+linear_solver_options_prefix = 'pinit_'
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+else:
+    multilevelLinearSolver = KSP_petsc4py
+    levelLinearSolver      = KSP_petsc4py
+    parallelPartitioningType    = parallelPartitioningType
+    nLayersOfOverlapForParallel = nLayersOfOverlapForParallel
+    nonlinearSmoother = None
+    linearSmoother    = None
+
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+#linear solve rtolerance
+
+linTolFac = 0.0
+l_atol_res = 0.01*ct.phi_nl_atol_res
+tolFac = 0.0
+nl_atol_res = ct.phi_nl_atol_res
+nonlinearSolverConvergenceTest = 'r'
+levelNonlinearSolverConvergenceTest = 'r'
+linearSolverConvergenceTest             = 'r-true'
+maxLineSearches=0
+periodicDirichletConditions=None
+
+conservativeFlux=None

--- a/2d/sediment/strip_sediment/pressureInitial_p.py
+++ b/2d/sediment/strip_sediment/pressureInitial_p.py
@@ -1,0 +1,43 @@
+from math import *
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import PresInit
+from proteus import Context
+from tank import *
+
+ct = Context.get()
+name = "pressureInitial"
+
+coefficients=PresInit.Coefficients(nd=nd,
+                                   modelIndex=ct.PI_model,
+                                   fluidModelIndex=ct.V_model,
+                                   pressureModelIndex=ct.P_model)
+
+#pressure increment should be zero on any pressure dirichlet boundaries
+
+#the advectiveFlux should be zero on any no-flow  boundaries
+
+
+class getIBC_pInit:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+class PerturbedSurface_p:
+    def __init__(self,waterLevel):
+        self.waterLevel=waterLevel
+    def uOfXT(self,x,t):
+        self.vos = ct.vos_function(x)
+        self.rho_a = rho_1#(1.-self.vos)*rho_1 + (self.vos)*ct.rho_s
+        self.rho_w = rho_0#(1.-self.vos)*rho_0 + (self.vos)*ct.rho_s
+        if signedDistance(x) < 0:
+            return -(L[1] - self.waterLevel)*self.rho_a*g[1] - (self.waterLevel - x[1])*self.rho_w*g[1]
+        else:
+            return -(L[1] - x[1])*self.rho_a*g[1]
+
+initialConditions = {0:PerturbedSurface_p(waterLine_z)} #getIBC_pInit()}
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].pInit_dirichlet.init_cython()}
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].pInit_advective.init_cython()}
+diffusiveFluxBoundaryConditions = {0:{0: lambda x, flag: domain.bc[flag].pInit_diffusive.init_cython()}}

--- a/2d/sediment/strip_sediment/pressure_n.py
+++ b/2d/sediment/strip_sediment/pressure_n.py
@@ -1,0 +1,53 @@
+from proteus import *
+from proteus.default_n import *
+from pressure_p import *
+
+
+mesh = domain.MeshOptions
+triangleOptions = triangleOptions
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+
+femSpaces = {0:ct.pbasis}
+
+
+# stepController  = StepControl.Min_dt_cfl_controller
+# runCFL= 0.99
+# runCFL= 0.5
+
+stepController=FixedStep
+
+#matrix type
+numericalFluxType = NumericalFlux.ConstantAdvection_exterior
+#numericalFluxType = NumericalFlux
+matrix = LinearAlgebraTools.SparseMatrix
+
+linear_solver_options_prefix = 'pressure_'
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+else:
+    multilevelLinearSolver = KSP_petsc4py
+    levelLinearSolver      = KSP_petsc4py
+    parallelPartitioningType    = parallelPartitioningType
+    nLayersOfOverlapForParallel = nLayersOfOverlapForParallel
+    nonlinearSmoother = None
+    linearSmoother    = None
+
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+#linear solve rtolerance
+
+linTolFac = 0.0
+l_atol_res = 0.1*ct.pressure_nl_atol_res
+tolFac = 0.0
+nl_atol_res = ct.pressure_nl_atol_res
+maxLineSearches = 0
+nonlinearSolverConvergenceTest      = 'r'
+levelNonlinearSolverConvergenceTest = 'r'
+linearSolverConvergenceTest         = 'r-true'
+
+periodicDirichletConditions=None
+
+conservativeFlux=None

--- a/2d/sediment/strip_sediment/pressure_p.py
+++ b/2d/sediment/strip_sediment/pressure_p.py
@@ -1,0 +1,34 @@
+from math import *
+from proteus import *
+from proteus.default_p import *
+from proteus.mprans import Pres
+from proteus import Context
+from tank import *
+
+ct = Context.get()
+name = "pressure"
+
+LevelModelType = Pres.LevelModel
+
+coefficients=Pres.Coefficients(modelIndex=ct.P_model,
+                               fluidModelIndex=ct.V_model,
+                               pressureIncrementModelIndex=ct.DP_model,
+                               useRotationalForm=True)
+
+
+class getIBC_p:
+    def __init__(self,waterLevel):
+        self.waterLevel=waterLevel
+    def uOfXT(self,x,t):
+        self.vos = ct.vos_function(x)
+        self.rho_a = rho_1#(1.-self.vos)*rho_1 + (self.vos)*ct.rho_s
+        self.rho_w = rho_0#(1.-self.vos)*rho_0 + (self.vos)*ct.rho_s
+        if signedDistance(x) < 0:
+            return -(L[1] - self.waterLevel)*self.rho_a*g[1] - (self.waterLevel - x[1])*self.rho_w*g[1]
+        else:
+            return -(L[1] - x[1])*self.rho_a*g[1]
+
+initialConditions = {0:getIBC_p(waterLine_z)}
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].p_dirichlet.init_cython() } # pressure bc are explicitly set
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].pInit_advective.init_cython()}

--- a/2d/sediment/strip_sediment/pressureincrement_n.py
+++ b/2d/sediment/strip_sediment/pressureincrement_n.py
@@ -1,0 +1,56 @@
+from proteus import *
+from proteus.default_n import *
+from pressureincrement_p import *
+
+mesh = domain.MeshOptions
+triangleOptions = triangleOptions
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+
+femSpaces = {0:pbasis}
+
+stepController=FixedStep
+
+#numericalFluxType = PresInc.NumericalFlux
+numericalFluxType = NumericalFlux.ConstantAdvection_exterior
+matrix = LinearAlgebraTools.SparseMatrix
+
+#if openTop:
+#    linearSmoother    = None
+#    multilevelLinearSolver = LinearSolvers.LU
+#    levelLinearSolver      = LinearSolvers.LU
+#else:
+#    linearSmoother         = LinearSolvers.NavierStokesPressureCorrection # pure neumann laplacian solver
+#    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+#    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+linear_solver_options_prefix = 'phi_'
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+else:
+    multilevelLinearSolver = KSP_petsc4py
+    levelLinearSolver      = KSP_petsc4py
+    parallelPartitioningType    = parallelPartitioningType
+    nLayersOfOverlapForParallel = nLayersOfOverlapForParallel
+    nonlinearSmoother = None
+    linearSmoother    = None
+
+
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+#linear solve rtolerance
+
+linTolFac = 0.0
+l_atol_res = 0.01*phi_nl_atol_res
+tolFac = 0.0
+nl_atol_res = phi_nl_atol_res
+nonlinearSolverConvergenceTest = 'r'
+levelNonlinearSolverConvergenceTest = 'r'
+linearSolverConvergenceTest             = 'r-true'
+maxLineSearches=0
+periodicDirichletConditions=None
+
+conservativeFlux = {0:'point-eval'} #'point-eval','pwl-bdm-opt'
+#conservativeFlux=None

--- a/2d/sediment/strip_sediment/pressureincrement_p.py
+++ b/2d/sediment/strip_sediment/pressureincrement_p.py
@@ -1,0 +1,50 @@
+from math import *
+from proteus import *
+from proteus.default_p import *
+from tank import *
+import tank_so
+from proteus.mprans import PresInc
+from proteus import Context
+
+ct = Context.get()
+
+
+#domain = ctx.domain
+#nd = ctx.nd
+name = "pressureincrement"
+
+LevelModelType = PresInc.LevelModel
+#from ProjectionScheme import PressureIncrement
+#coefficients=PressureIncrement(rho_f_min = rho_1,
+#                               rho_s_min = rho_s,
+#                               nd = nd,
+#                               modelIndex=PINC_model,
+#                               fluidModelIndex=V_model)
+from proteus.mprans import PresInc
+coefficients=PresInc.Coefficients(rho_f_min = (1.0-1.0e-8)*rho_1,
+                                  rho_s_min = (1.0-1.0e-8)*rho_s,
+                                  nd = nd,
+                                  modelIndex= ct.DP_model,
+                                  fluidModelIndex= ct.V_model,
+                                  sedModelIndex= ct.SED_model,
+                                  VOF_model= ct.VOF_model,
+                                  VOS_model= ct.VOS_model,
+                                  fixNullSpace=fixNullSpace_PresInc, 
+                                  INTEGRATE_BY_PARTS_DIV_U=ct.INTEGRATE_BY_PARTS_DIV_U_PresInc)
+
+
+#pressure increment should be zero on any pressure dirichlet boundaries
+
+#the advectiveFlux should be zero on any no-flow  boundaries
+
+class getIBC_phi:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+initialConditions = {0:getIBC_phi()}
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].pInc_dirichlet.init_cython()}
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].pInc_advective.init_cython()}
+diffusiveFluxBoundaryConditions = {0:{0: lambda x, flag: domain.bc[flag].pInc_diffusive.init_cython()}}

--- a/2d/sediment/strip_sediment/redist_n.py
+++ b/2d/sediment/strip_sediment/redist_n.py
@@ -1,0 +1,95 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools,
+                     NumericalFlux)
+from proteus.mprans import RDLS3P
+import redist_p as physics
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+# time stepping
+runCFL = ct.runCFL
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0: ct.basis}
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+massLumping       = False
+numericalFluxType = NumericalFlux.DoNothing
+conservativeFlux  = None
+subgridError      = RDLS3P.SubgridError(physics.coefficients,nd)
+shockCapturing    = RDLS3P.ShockCapturing(physics.coefficients,nd,shockCapturingFactor=ct.rd_shockCapturingFactor,lag=ct.rd_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver  = NonlinearSolvers.Newton
+levelNonlinearSolver       = NonlinearSolvers.Newton
+
+nonlinearSmoother = NonlinearSolvers.NLGaussSeidel
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+if ct.redist_Newton:
+    timeIntegration = NoIntegration
+    stepController = ct.Newton_controller
+    maxNonlinearIts = 50
+    maxLineSearches = 0
+    nonlinearSolverConvergenceTest = 'rits'
+    levelNonlinearSolverConvergenceTest = 'rits'
+    linearSolverConvergenceTest = 'r-true'
+    useEisenstatWalker = False
+else:
+    timeIntegration = BackwardEuler_cfl
+    stepController = RDLS3P.PsiTC
+    runCFL=2.0
+    psitc['nStepsForce']=3
+    psitc['nStepsMax']=50
+    psitc['reduceRatio']=10.0
+    psitc['startRatio']=1.0
+    rtol_res[0] = 0.0
+    atol_res[0] = rd_nl_atol_res
+    useEisenstatWalker = False#True
+    maxNonlinearIts = 1
+    maxLineSearches = 0
+    nonlinearSolverConvergenceTest = 'rits'
+    levelNonlinearSolverConvergenceTest = 'rits'
+    linearSolverConvergenceTest = 'r-true'
+
+linear_solver_options_prefix = 'rdls_'
+
+tolFac = 0.0
+nl_atol_res = ct.rd_nl_atol_res
+linTolFac = 0.01
+l_atol_res = 0.01*ct.rd_nl_atol_res
+useEisenstatWalker = False#True

--- a/2d/sediment/strip_sediment/redist_p.py
+++ b/2d/sediment/strip_sediment/redist_p.py
@@ -1,0 +1,46 @@
+from proteus import StepControl
+from proteus import *
+from proteus.default_p import *
+from math import *
+from proteus.mprans import RDLS3P
+from proteus import Context
+
+"""
+The redistancing equation in the sloshbox test problem.
+"""
+
+ct = Context.get()
+domain = ct.domain
+nd = domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+
+LevelModelType = RDLS3P.LevelModel
+
+
+
+coefficients = RDLS3P.Coefficients(applyRedistancing=ct.applyRedistancing,
+                                   epsFact=ct.epsFact_redistance,
+                                   nModelId=ct.LS_model,
+                                   rdModelId=ct.RD_model,
+                                   useMetrics=ct.useMetrics,
+                                   backgroundDiffusionFactor=ct.backgroundDiffusionFactor)
+
+def getDBC_rd(x,flag):
+    pass
+
+dirichletConditions     = {0:getDBC_rd}
+weakDirichletConditions = {0:RDLS3P.setZeroLSweakDirichletBCsSimple}
+
+advectiveFluxBoundaryConditions =  {}
+diffusiveFluxBoundaryConditions = {0:{}}
+
+class PHI_IC:
+    def uOfXT(self, x, t):
+        return x[nd-1] - ct.waterLevel
+
+initialConditions  = {0: PHI_IC()}

--- a/2d/sediment/strip_sediment/tank.py
+++ b/2d/sediment/strip_sediment/tank.py
@@ -1,0 +1,476 @@
+from proteus import StepControl
+from math import *
+import proteus.MeshTools
+from proteus import Domain, Context
+from proteus.default_n import *
+from proteus.Profiling import logEvent
+from proteus.mprans import SpatialTools as st
+from proteus import Gauges as ga
+from proteus import WaveTools as wt
+from proteus.mprans.SedClosure import  HsuSedStress
+
+
+opts=Context.Options([
+    # Geometry and sed parameters
+    ("waterLine_x", 10.00, "Width of free surface from left to right"),
+    ("waterLine_z", 2., "Heigth of free surface above bottom"),
+    ("sediment_level", 1.75, "Height of the sediment column"),
+    ("sediment_bottom", -1.25, "Height of the sediment column"),
+    ("Lx", 1.50, "Length of the numerical domain"),
+    ("Ly", 3., "Heigth of the numerical domain"),
+    ("dtout", 0.05, "Time interval for output"),
+    #fluid parameters
+    ("rho_0", 998.2, "water density"),
+    ("rho_1", 1.205, "air density"),
+    ("nu_0", 1e-6, "water kin viscosity"),
+    ("nu_1", 1.5e-5, "air kin viscosity"),
+    ('g',np.array([0.0, -9.8, 0.0]),'Gravitational acceleration'),    
+    # sediment parameters
+    ('cSed', 0.55,'Initial sediment concentration'),
+    ('rho_s',2600 ,'sediment material density'),
+    ('alphaSed', 150.,'laminar drag coefficient'),
+    ('betaSed', 1.72,'turbulent drag coefficient'),
+    ('grain',0.0025, 'Grain size'),
+    ('packFraction',0.2,'threshold for loose / packed sediment'),
+    ('packMargin',0.01,'transition margin for loose / packed sediment'),
+    ('maxFraction',0.635,'fraction at max  sediment packing'),
+    ('frFraction',0.57,'fraction where contact stresses kick in'),
+    ('sigmaC',0.57,'Schmidt coefficient for turbulent diffusion'),
+    ('C3e',1.2,'Dissipation coefficient '),
+    ('C4e',1.2,'Dissipation coefficient'),
+    ('eR', 0.8, 'Collision stress coefficient (module not functional)'),
+    ('fContact', 0.05,'Contact stress coefficient'),
+    ('mContact', 3.0,'Contact stress coefficient'),
+    ('nContact', 5.0,'Contact stress coefficient'),
+    ('angFriction', pi/6., 'Angle of friction'),
+    ('vos_limiter', 0.62, 'Weak limiter for vos'),
+    ('mu_fr_limiter', 1e-3,'Hard limiter for contact stress friction coeff'),
+     # numerical options
+    ("refinement", 25.,"L[0]/refinement"),
+    ("sedimentDynamics", True, "Enable sediment dynamics module"),
+    ("cfl", 0.25 ,"Target cfl"),
+    ("duration", 10.0 ,"Duration of the simulation"),
+    ("PSTAB", 1.0, "Affects subgrid error"),
+    ("res", 1.0e-8, "Residual tolerance"),
+    ("epsFact_density", 3.0, "Control width of water/air transition zone"),
+    ("epsFact_consrv_diffusion", 1.0, "Affects smoothing diffusion in mass conservation"),
+    ("useRANS", 0, "Switch ON turbulence models: 0-None, 1-K-Epsilon, 2-K-Omega1998, 3-K-Omega1988"),
+    # ns_closure: 1-classic smagorinsky, 2-dynamic smagorinsky, 3-k-epsilon, 4-k-omega
+    ("sigma_k", 1.0, "sigma_k coefficient for the turbulence model"),
+    ("sigma_e", 1.0, "sigma_e coefficient for the turbulence model"),
+    ("Cmu", 0.09, "Cmu coefficient for the turbulence model"),
+    ])
+
+# SO Models
+
+VOS_model = 0
+VOF_model = 1
+LS_model = 2
+RD_model = 3
+MCORR_model =4
+SED_model =5
+V_model =6
+DP_model = 7
+P_model = 8
+
+
+if opts.useRANS:
+    K_model = 9
+    EPS_model = 10
+    PI_model = 11
+else:
+    K_model = None
+    EPS_model = None   
+    PI_model = 9
+
+# Domain dimensions
+
+nd = 2
+
+# ----- Sediment stress ----- #
+
+sedClosure = HsuSedStress(aDarcy =  opts.alphaSed,
+                          betaForch =  opts.betaSed,
+                          grain =  opts.grain,
+                          packFraction =  opts.packFraction,
+                          packMargin =  opts.packMargin,
+                          maxFraction =  opts.maxFraction,
+                          frFraction =  opts.frFraction,
+                          sigmaC =  opts.sigmaC,
+                          C3e =  opts.C3e,
+                          C4e =  opts.C4e,
+                          eR =  opts.eR,
+                          fContact =  opts.fContact,
+                          mContact =  opts.mContact,
+                          nContact =  opts.nContact,
+                          angFriction =  opts.angFriction,
+                          vos_limiter = opts.vos_limiter,
+                          mu_fr_limiter = opts.mu_fr_limiter,
+                          )
+
+# ----- DOMAIN ----- #
+
+domain = Domain.PlanarStraightLineGraphDomain()
+
+
+# ----- Phisical constants ----- #
+  
+# Water
+rho_0 = opts.rho_0
+nu_0 = opts.nu_0
+
+# Air
+rho_1 = opts.rho_1
+nu_1 = opts.nu_1
+
+# Sediment
+
+rho_s = opts.rho_s
+nu_s = 1000000
+dragAlpha = 0.0
+
+# Surface tension
+sigma_01 = 0.0
+
+# Gravity
+g = opts.g
+gamma_0 = abs(g[1])*rho_0
+
+# Initial condition
+waterLine_x = opts.waterLine_x
+waterLine_z = opts.waterLine_z
+sediment_level = opts.sediment_level
+sediment_bottom = opts.sediment_bottom
+waterLevel = waterLine_z
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Domain and mesh
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+L = (opts.Lx, opts.Ly)
+he = L[0]/opts.refinement
+dim = dimx, dimy = L
+coords = [ dimx/2., dimy/2. ]
+
+boundaryOrientations = {'y-': np.array([0., -1.,0.]),
+                        'x+': np.array([+1, 0.,0.]),
+                        'y+': np.array([0., +1.,0.]),
+                        'x-': np.array([-1., 0.,0.]),
+                        'sponge': None,
+                           }
+boundaryTags = {'y-': 1,
+                    'x+': 2,
+                    'y+': 3,
+                    'x-': 4,
+                    'sponge': 5,
+                       }
+
+tank = st.Rectangle(domain, dim=dim, coords=coords)
+
+
+#############################################################################################################################################################################################################################################################################################################################################################################################
+# ----- BOUNDARY CONDITIONS ----- #
+#############################################################################################################################################################################################################################################################################################################################################################################################
+
+tank.BC['y-'].setFreeSlip()
+
+tank.BC['y+'].setAtmosphere(orientation=np.array([0., +1.,0.]))
+
+tank.BC['x-'].setFreeSlip()
+
+tank.BC['x+'].setFreeSlip()
+
+
+
+
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Turbulence
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+
+if opts.useRANS:
+    kInflow = 1e-6
+    dissipationInflow = 1e-6
+    tank.BC['x-'].setTurbulentZeroGradient()
+    tank.BC['x+'].setTurbulentZeroGradient()
+    tank.BC['y-'].setTurbulentZeroGradient()
+    tank.BC['y+'].setTurbulentZeroGradient()
+
+
+######################################################################################################################################################################################################################
+# Gauges and probes #
+######################################################################################################################################################################################################################
+
+T=opts.duration
+PG = []
+gauge_dy=0.01
+tank_dim_y=dimy
+nprobes=int(tank_dim_y/gauge_dy)+1
+probes=np.linspace(0., tank_dim_y, nprobes)
+for i in probes:
+    PG.append((dimx/2., i, 0.),)
+v_output = ga.PointGauges(gauges=((('u',), PG),
+                                  (('v',), PG),),
+                          activeTime = (0., T),
+                          sampleRate=0.,
+                          fileName='fluidVelocityGauges.csv')
+vs_output = ga.PointGauges(gauges=((('us',),PG), 
+                                   (('vs',),PG),),
+                          activeTime = (0., T),
+                          sampleRate=0.,
+                          fileName='solidVelocityGauges.csv')
+vos_output = ga.PointGauges(gauges=((('vos',),PG),),
+                          activeTime = (0., T),
+                          sampleRate=0.,
+                          fileName='solidFractionGauges.csv')
+
+
+######################################################################################################################################################################################################################
+# Numerical Options and other parameters #
+######################################################################################################################################################################################################################
+ 
+domain.MeshOptions.he = he
+
+from math import *
+from proteus import MeshTools, AuxiliaryVariables
+import numpy
+import proteus.MeshTools
+from proteus import Domain
+from proteus.Profiling import logEvent
+from proteus.default_n import *
+from proteus.ctransportCoefficients import smoothedHeaviside
+from proteus.ctransportCoefficients import smoothedHeaviside_integral
+
+st.assembleDomain(domain)
+
+
+#----------------------------------------------------
+# Time stepping and velocity
+#----------------------------------------------------
+
+T=opts.duration
+weak_bc_penalty_constant = 10.0/nu_0 #100
+dt_fixed = opts.dtout
+dt_init = min(0.1*dt_fixed,0.001)
+nDTout= int(round(T/dt_fixed))
+runCFL = opts.cfl
+
+sedimentDynamics=opts.sedimentDynamics
+
+#----------------------------------------------------
+#  Discretization -- input options
+#----------------------------------------------------
+
+genMesh = True
+movingDomain = False
+applyRedistancing = True
+useOldPETSc = False
+useSuperlu = False
+timeDiscretization = 'be'#'vbdf'#'vbdf'  # 'vbdf', 'be', 'flcbdf'
+spaceOrder = 1
+pspaceOrder = 1
+useHex = False
+useRBLES = 0.0
+useMetrics = 1.0
+applyCorrection = True
+useVF = 1.0
+useOnlyVF = False
+useRANS = opts.useRANS  # 0 -- None
+                        # 1 -- K-Epsilon
+                        # 2 -- K-Omega
+
+
+KILL_PRESSURE_TERM = False
+fixNullSpace_PresInc = True
+INTEGRATE_BY_PARTS_DIV_U_PresInc = True
+CORRECT_VELOCITY = True
+STABILIZATION_TYPE = 0 #0: SUPG, 1: EV via weak residual, 2: EV via strong residual
+
+# Input checks
+if spaceOrder not in [1, 2]:
+    print "INVALID: spaceOrder" + spaceOrder
+    sys.exit()
+
+if useRBLES not in [0.0, 1.0]:
+    print "INVALID: useRBLES" + useRBLES
+    sys.exit()
+
+if useMetrics not in [0.0, 1.0]:
+    print "INVALID: useMetrics"
+    sys.exit()
+
+#  Discretization
+nd = tank.nd
+
+if spaceOrder == 1:
+    hFactor = 1.0
+    if useHex:
+        basis = C0_AffineLinearOnCubeWithNodalBasis
+        elementQuadrature = CubeGaussQuadrature(nd, 2)
+        elementBoundaryQuadrature = CubeGaussQuadrature(nd - 1, 2)
+    else:
+        basis = C0_AffineLinearOnSimplexWithNodalBasis
+        elementQuadrature = SimplexGaussQuadrature(nd, 3)
+        elementBoundaryQuadrature = SimplexGaussQuadrature(nd - 1, 3)
+elif spaceOrder == 2:
+    hFactor = 0.5
+    if useHex:
+        basis = C0_AffineLagrangeOnCubeWithNodalBasis
+        elementQuadrature = CubeGaussQuadrature(nd, 4)
+        elementBoundaryQuadrature = CubeGaussQuadrature(nd - 1, 4)
+    else:
+        basis = C0_AffineQuadraticOnSimplexWithNodalBasis
+        elementQuadrature = SimplexGaussQuadrature(nd, 4)
+        elementBoundaryQuadrature = SimplexGaussQuadrature(nd - 1, 4)
+
+if pspaceOrder == 1:
+    if useHex:
+        pbasis = C0_AffineLinearOnCubeWithNodalBasis
+    else:
+        pbasis = C0_AffineLinearOnSimplexWithNodalBasis
+elif pspaceOrder == 2:
+    if useHex:
+        pbasis = C0_AffineLagrangeOnCubeWithNodalBasis
+    else:
+        pbasis = C0_AffineQuadraticOnSimplexWithNodalBasis
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Numerical parameters
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+ns_forceStrongDirichlet = False
+ns_sed_forceStrongDirichlet = False
+backgroundDiffusionFactor=0.01
+
+if useMetrics:
+    ns_shockCapturingFactor = 0.5
+    ns_lag_shockCapturing = True
+    ns_lag_subgridError = True
+    ns_sed_shockCapturingFactor = 0.5
+    ns_sed_lag_shockCapturing = True
+    ns_sed_lag_subgridError = True
+    ls_shockCapturingFactor = 0.5
+    ls_lag_shockCapturing = True
+    ls_sc_uref = 1.0
+    ls_sc_beta = 1.0
+    vof_shockCapturingFactor = 0.5
+    vof_lag_shockCapturing = True
+    vof_sc_uref = 1.0
+    vof_sc_beta = 1.0
+    vos_shockCapturingFactor = 0.9#opts.vos_SC # <------------------------------------- 
+    vos_lag_shockCapturing = True
+    vos_sc_uref = 1.0
+    vos_sc_beta = 1.0
+    rd_shockCapturingFactor = 0.5
+    rd_lag_shockCapturing = False
+    epsFact_vos =opts.epsFact_density
+    epsFact_density = opts.epsFact_density # 1.5
+    epsFact_viscosity = epsFact_curvature = epsFact_vof = epsFact_consrv_heaviside = epsFact_consrv_dirac = epsFact_density
+    epsFact_redistance = 0.33
+    epsFact_consrv_diffusion = opts.epsFact_consrv_diffusion # 0.1
+    redist_Newton = True
+    kappa_shockCapturingFactor = 0.25
+    kappa_lag_shockCapturing = True  #False
+    kappa_sc_uref = 1.0
+    kappa_sc_beta = 1.0
+    dissipation_shockCapturingFactor = 0.25
+    dissipation_lag_shockCapturing = True  #False
+    dissipation_sc_uref = 1.0
+    dissipation_sc_beta = 1.0
+else:
+    ns_shockCapturingFactor = 0.9
+    ns_lag_shockCapturing = True
+    ns_lag_subgridError = True
+    ns_sed_shockCapturingFactor = 0.9
+    ns_sed_lag_shockCapturing = True
+    ns_sed_lag_subgridError = True
+    ls_shockCapturingFactor = 0.9
+    ls_lag_shockCapturing = True
+    ls_sc_uref = 1.0
+    ls_sc_beta = 1.0
+    vof_shockCapturingFactor = 0.9
+    vof_lag_shockCapturing = True
+    vof_sc_uref = 1.0
+    vof_sc_beta = 1.0
+    vos_shockCapturingFactor = 5.
+    vos_lag_shockCapturing = True
+    vos_sc_uref = 1.0
+    vos_sc_beta = 1.0
+    rd_shockCapturingFactor = 0.9
+    rd_lag_shockCapturing = False
+    epsFact_density = opts.epsFact_density # 1.5
+    epsFact_viscosity = epsFact_curvature = epsFact_vof = epsFact_vos = epsFact_consrv_heaviside = epsFact_consrv_dirac = epsFact_density
+    epsFact_redistance = 0.33
+    epsFact_consrv_diffusion = opts.epsFact_consrv_diffusion # 1.0
+    redist_Newton = False
+    kappa_shockCapturingFactor = 0.9
+    kappa_lag_shockCapturing = True  #False
+    kappa_sc_uref = 1.0
+    kappa_sc_beta = 1.0
+    dissipation_shockCapturingFactor = 0.9
+    dissipation_lag_shockCapturing = True  #False
+    dissipation_sc_uref = 1.0
+    dissipation_sc_beta = 1.0
+
+ns_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+ns_sed_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+vof_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+vos_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+ls_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+rd_nl_atol_res =  max(opts.res, 0.005 * he)
+mcorr_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+kappa_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+dissipation_nl_atol_res =  max(opts.res, 0.001 * he ** 2)
+phi_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+pressure_nl_atol_res = max(opts.res, 0.001 * he ** 2)
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Turbulence
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+ns_closure = 0  #1-classic smagorinsky, 2-dynamic smagorinsky, 3 -- k-epsilon, 4 -- k-omega
+ns_sed_closure = 0  #1-classic smagorinsky, 2-dynamic smagorinsky, 3 -- k-epsilon, 4 -- k-omega
+if useRANS == 1:
+    ns_closure = 3
+elif useRANS == 2:
+    ns_closure == 4
+
+
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+# Functions for model variables - Initial conditions
+####################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################
+
+def signedDistance(x):
+    phi_z = x[1] - waterLine_z
+    return phi_z
+
+def vos_signedDistance(x):
+    phi_z1 = x[1] - sediment_level
+    phi_z2 = sediment_bottom - x[1]
+    if abs(phi_z1) < abs(phi_z2):
+        phi_z = phi_z1
+    else:
+        phi_z = phi_z2
+    return phi_z
+
+class Suspension_class:
+    def __init__(self):
+        pass
+    def uOfXT(self, x, t=0):
+        phi = vos_signedDistance(x)
+        smoothing = (epsFact_consrv_heaviside)*he/2.
+        Heav = smoothedHeaviside(smoothing, phi)      
+        if phi <= -smoothing:
+            return opts.cSed
+        elif -smoothing < phi < smoothing:
+            return opts.cSed * (1.-Heav)            
+        else:
+            return 1e-10    
+
+Suspension = Suspension_class()
+
+vos_function = Suspension.uOfXT

--- a/2d/sediment/strip_sediment/tank_so.py
+++ b/2d/sediment/strip_sediment/tank_so.py
@@ -1,0 +1,86 @@
+from proteus import StepControl
+"""
+Split operator module for two-phase flow
+"""
+
+from proteus.default_so import *
+import os
+from proteus import Context
+
+# Create context from main module
+name_so = os.path.basename(__file__)
+if '_so.py' in name_so[-6:]:
+    name = name_so[:-6]
+elif '_so.pyc' in name_so[-7:]:
+    name = name_so[:-7]
+else:
+    raise NameError, 'Split operator module must end with "_so.py"'
+
+try:
+    case = __import__(name)
+    Context.setFromModule(case)
+    ct = Context.get()
+except ImportError:
+    raise ImportError, str(name) + '.py not found'
+
+from proteus import BoundaryConditions
+for BC in ct.domain.bc:
+    BC.getContext()
+
+from proteus.SplitOperator import Sequential_FixedStep_Simple, defaultSystem
+if ct.sedimentDynamics:
+    pnList = [("vos_p",               "vos_n"),#0
+              ("vof_p",               "vof_n"),#1
+              ("ls_p",                "ls_n"),#2
+              ("redist_p",            "redist_n"),#3
+              ("ls_consrv_p",         "ls_consrv_n"),#4
+              ("threep_navier_stokes_sed_p", "threep_navier_stokes_sed_n"),#5
+              ("twp_navier_stokes_p", "twp_navier_stokes_n"),#6
+              ("pressureincrement_p", "pressureincrement_n"),#7
+              ("pressure_p", "pressure_n")]#8
+    
+else:
+    pnList = [("vof_p",               "vof_n"),#0
+              ("ls_p",                "ls_n"),#1
+              ("redist_p",            "redist_n"),#2
+              ("ls_consrv_p",         "ls_consrv_n"),#3
+              ("twp_navier_stokes_p", "twp_navier_stokes_n"),#4
+              ("pressureincrement_p", "pressureincrement_n"),#5
+              ("pressure_p", "pressure_n")]#6
+
+if ct.useRANS > 0:
+    pnList.append(("kappa_p",
+                   "kappa_n"))#7 or #9
+    pnList.append(("dissipation_p",
+                   "dissipation_n"))#8 or #10
+
+pnList.append(("pressureInitial_p",
+                   "pressureInitial_n"))#7 or #9
+
+        
+              
+name = "tank"
+
+#modelSpinUpList = [ct.VOF_model, ct.LS_model, ct.V_model, ct.PINIT_model]
+modelSpinUpList = [ct.PI_model]
+
+class Sequential_MinAdaptiveModelStepPS(Sequential_MinAdaptiveModelStep):
+    def __init__(self,modelList,system=defaultSystem,stepExact=True):
+        Sequential_MinAdaptiveModelStep.__init__(self,modelList,system,stepExact)
+        self.modelList = modelList[:len(pnList)-1]
+
+#class Sequential_MinAdaptiveModelStepPS(Sequential_FixedStep):
+#    def __init__(self,modelList,system=defaultSystem,stepExact=True):
+#        Sequential_FixedStep.__init__(self,modelList,system,stepExact)
+#        self.modelList = modelList[:len(pnList)-1]
+#dt_system_fixed = ct.dt_fixed
+
+systemStepControllerType = Sequential_MinAdaptiveModelStepPS
+
+needEBQ_GLOBAL = False
+needEBQ = False
+
+tnList = [0.0,ct.dt_init]+[ct.dt_init+i*ct.dt_fixed for i in range(1,ct.nDTout+1)]
+
+info = open("TimeList.txt","w")
+#archiveFlag = ArchiveFlags.EVERY_SEQUENCE_STEP

--- a/2d/sediment/strip_sediment/testSeries_single
+++ b/2d/sediment/strip_sediment/testSeries_single
@@ -1,0 +1,15 @@
+# Single phase
+#parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=25 rho_1=998.2 nu_1=1e-6 cSed=0.001 grain=0.0001" -D case_A1
+#parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=25 rho_1=998.2 nu_1=1e-6 cSed=0.001 grain=0.00025" -D case_A2
+#parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=25 rho_1=998.2 nu_1=1e-6 cSed=0.001 grain=0.0005" -D case_A3
+#parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=25 rho_1=998.2 nu_1=1e-6 cSed=0.001 grain=0.001" -D case_A4
+#parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=25 rho_1=998.2 nu_1=1e-6 cSed=0.001 grain=0.0025" -D case_A5 
+#parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=25 rho_1=998.2 nu_1=1e-6 cSed=0.05 grain=0.0001" -D case_B1
+#parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=25 rho_1=998.2 nu_1=1e-6 cSed=0.05 grain=0.00025" -D case_B2
+#parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=25 rho_1=998.2 nu_1=1e-6 cSed=0.05 grain=0.0005" -D case_B3
+#parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=25 rho_1=998.2 nu_1=1e-6 cSed=0.05 grain=0.001" -D case_B4
+#parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=25 rho_1=998.2 nu_1=1e-6 cSed=0.05 grain=0.0025" -D case_B5 
+#parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=12.5 rho_1=998.2 nu_1=1e-6 cSed=0.001 grain=0.0001" -D case_A1b
+#parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=50 rho_1=998.2 nu_1=1e-6 cSed=0.001 grain=0.0001" -D case_A1c
+parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=12.5 rho_1=998.2 nu_1=1e-6 cSed=0.05 grain=0.0001" -D case_B1b
+parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=50 rho_1=998.2 nu_1=1e-6 cSed=0.05 grain=0.0001" -D case_B1c

--- a/2d/sediment/strip_sediment/testSeries_single_refined
+++ b/2d/sediment/strip_sediment/testSeries_single_refined
@@ -1,0 +1,15 @@
+# Single phase
+#parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=50 rho_1=998.2 nu_1=1e-6 cSed=0.001 grain=0.0001" -D case_A1c
+#parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=50 rho_1=998.2 nu_1=1e-6 cSed=0.001 grain=0.00025" -D case_A2c
+#parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=50 rho_1=998.2 nu_1=1e-6 cSed=0.001 grain=0.0005" -D case_A3c
+parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=50 rho_1=998.2 nu_1=1e-6 cSed=0.001 grain=0.001" -D case_A4c
+parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=50 rho_1=998.2 nu_1=1e-6 cSed=0.001 grain=0.0025" -D case_A5c 
+parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=50 rho_1=998.2 nu_1=1e-6 cSed=0.05 grain=0.0001" -D case_B1c
+parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=50 rho_1=998.2 nu_1=1e-6 cSed=0.05 grain=0.00025" -D case_B2c
+parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=50 rho_1=998.2 nu_1=1e-6 cSed=0.05 grain=0.0005" -D case_B3c
+parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=50 rho_1=998.2 nu_1=1e-6 cSed=0.05 grain=0.001" -D case_B4c
+parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=50 rho_1=998.2 nu_1=1e-6 cSed=0.05 grain=0.0025" -D case_B5c 
+#parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=12.5 rho_1=998.2 nu_1=1e-6 cSed=0.001 grain=0.0001" -D case_A1b
+#parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=50 rho_1=998.2 nu_1=1e-6 cSed=0.001 grain=0.0001" -D case_A1c
+#parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=12.5 rho_1=998.2 nu_1=1e-6 cSed=0.05 grain=0.0001" -D case_B1b
+#parun tank_so.py -l 3 -v -O ~/air-water-vv/inputTemplates/petsc.options.asm -C "duration=2. refinement=50 rho_1=998.2 nu_1=1e-6 cSed=0.05 grain=0.0001" -D case_B1c

--- a/2d/sediment/strip_sediment/threep_navier_stokes_sed_n.py
+++ b/2d/sediment/strip_sediment/threep_navier_stokes_sed_n.py
@@ -1,0 +1,72 @@
+from proteus import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+from threep_navier_stokes_sed_p import *
+from tank import *
+
+if timeDiscretization=='vbdf':
+    timeIntegration = VBDF
+    timeOrder=2
+    stepController  = Min_dt_cfl_controller
+elif timeDiscretization=='flcbdf':
+    timeIntegration = FLCBDF
+    #stepController = FLCBDF_controller_sys
+    stepController  = Min_dt_cfl_controller
+    time_tol = 10.0*ns_sed_nl_atol_res
+    atol_u = {0:time_tol,1:time_tol}
+    rtol_u = {0:time_tol,1:time_tol}
+else:
+    timeIntegration = BackwardEuler_cfl
+    stepController  = Min_dt_cfl_controller
+
+femSpaces = {0:basis,
+	     1:basis}
+
+massLumping       = False
+numericalFluxType = None
+conservativeFlux  = None
+
+numericalFluxType = RANS3PSed.NumericalFlux
+subgridError = RANS3PSed.SubgridError(coefficients,nd,lag=ns_sed_lag_subgridError,hFactor=hFactor)
+shockCapturing = RANS3PSed.ShockCapturing(coefficients,nd,ns_sed_shockCapturingFactor,lag=ns_sed_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+
+linearSmoother    = None
+
+matrix = SparseMatrix
+
+if useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'rans3p_sed_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest             = 'r-true'
+
+tolFac = 0.0
+linTolFac = 0.01
+l_atol_res = 0.01*ns_sed_nl_atol_res
+nl_atol_res = ns_sed_nl_atol_res
+useEisenstatWalker = False
+maxNonlinearIts = 50
+maxLineSearches = 0
+conservativeFlux = {0:'point-eval'}
+#conservativeFlux = {0:'pwl-bdm-opt'}
+#auxiliaryVariables=[pointGauges,lineGauges]
+auxiliaryVariables = ct.domain.auxiliaryVariables['thp']+[ct.vs_output]

--- a/2d/sediment/strip_sediment/threep_navier_stokes_sed_p.py
+++ b/2d/sediment/strip_sediment/threep_navier_stokes_sed_p.py
@@ -1,0 +1,81 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import RANS3PSed
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = RANS3PSed.LevelModel
+
+
+coefficients = RANS3PSed.Coefficients(epsFact=epsFact_viscosity,
+                                      sigma=0.0,
+                                      rho_0 = rho_0,
+                                      nu_0 = nu_0, 
+                                      rho_1 = rho_1,
+                                      nu_1 = nu_1,
+                                      rho_s = rho_s,
+                                      g=g,
+                                      nd=nd,
+                                      ME_model=ct.SED_model,
+                                      PRESSURE_model=ct.P_model,
+                                      FLUID_model=ct.V_model,
+                                      VOS_model=ct.VOS_model,
+                                      VOF_model=ct.VOF_model,
+                                      LS_model=ct.LS_model,
+                                      Closure_0_model=ct.K_model,
+                                      Closure_1_model=ct.EPS_model,
+                                      epsFact_density=epsFact_density,
+                                      stokes=False,
+                                      useVF=True,
+                                      useRBLES=useRBLES,
+                                      useMetrics=useMetrics,
+                                      eb_adjoint_sigma=1.0,
+                                      eb_penalty_constant=weak_bc_penalty_constant,
+                                      forceStrongDirichlet=ns_forceStrongDirichlet,
+                                      turbulenceClosureModel=ns_closure,
+                                      movingDomain=movingDomain,
+                                      dragAlpha=dragAlpha,
+                                      PSTAB=ct.opts.PSTAB,
+                                    aDarcy = sedClosure.aDarcy,
+                                    betaForch = sedClosure.betaForch,
+                                    grain = sedClosure.grain,
+                                    packFraction = sedClosure.packFraction,
+                                    maxFraction = sedClosure.maxFraction,
+                                    frFraction = sedClosure.frFraction,
+                                    sigmaC = sedClosure.sigmaC,
+                                    C3e = sedClosure.C3e,
+                                    C4e = sedClosure.C4e,
+                                    eR = sedClosure.eR,
+                                    fContact = sedClosure.fContact,
+                                    mContact = sedClosure.mContact,
+                                    nContact = sedClosure.nContact,
+                                    angFriction = sedClosure.angFriction,
+                                    vos_function = ct.vos_function,
+                                    staticSediment = False,
+                                    vos_limiter = ct.sedClosure.vos_limiter,
+                                    mu_fr_limiter = ct.sedClosure.mu_fr_limiter)
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].us_dirichlet.init_cython(),
+                       1: lambda x, flag: domain.bc[flag].vs_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].us_advective.init_cython(),
+                                   1: lambda x, flag: domain.bc[flag].vs_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {0: lambda x, flag: domain.bc[flag].us_diffusive.init_cython()},
+                                   1: {1: lambda x, flag: domain.bc[flag].vs_diffusive.init_cython()}}
+
+if nd == 3:
+    dirichletConditions[2] = lambda x, flag: domain.bc[flag].ws_dirichlet.init_cython()
+    advectiveFluxBoundaryConditions[2] = lambda x, flag: domain.bc[flag].ws_advective.init_cython()
+    diffusiveFluxBoundaryConditions[2] = {2: lambda x, flag: domain.bc[flag].ws_diffusive.init_cython()}
+
+class AtRest:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+initialConditions = {0:AtRest(),
+                     1:AtRest()}

--- a/2d/sediment/strip_sediment/twp_navier_stokes_n.py
+++ b/2d/sediment/strip_sediment/twp_navier_stokes_n.py
@@ -1,0 +1,74 @@
+from proteus import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+from twp_navier_stokes_p import *
+from tank import *
+
+if timeDiscretization=='vbdf':
+    timeIntegration = VBDF
+    timeOrder=2
+    stepController  = Min_dt_cfl_controller
+elif timeDiscretization=='flcbdf':
+    timeIntegration = FLCBDF
+    #stepController = FLCBDF_controller_sys
+    stepController  = Min_dt_cfl_controller
+    time_tol = 10.0*ns_nl_atol_res
+    atol_u = {0:time_tol,1:time_tol}
+    rtol_u = {0:time_tol,1:time_tol}
+else:
+    timeIntegration = BackwardEuler_cfl
+    stepController  = Min_dt_cfl_controller
+
+femSpaces = {0:basis,
+	     1:basis}
+#femSpaces = {0:C0_AffineQuadraticOnSimplexWithNodalBasis,
+#             1:C0_AffineQuadraticOnSimplexWithNodalBasis}
+
+massLumping       = False
+numericalFluxType = None
+conservativeFlux  = None
+
+numericalFluxType = RANS3PF.NumericalFlux
+subgridError = RANS3PF.SubgridError(coefficients,nd,lag=ns_lag_subgridError,hFactor=hFactor)
+shockCapturing = RANS3PF.ShockCapturing(coefficients,nd,ns_shockCapturingFactor,lag=ns_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+
+linearSmoother    = None #SimpleNavierStokes2D
+
+matrix = SparseMatrix
+
+if useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'rans2p_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest             = 'r-true'
+
+tolFac = 0.0
+linTolFac = 0.01
+l_atol_res = 0.01*ns_nl_atol_res
+nl_atol_res = ns_nl_atol_res
+useEisenstatWalker = False
+maxNonlinearIts = 50
+maxLineSearches = 0
+conservativeFlux = {0:'point-eval'}
+#conservativeFlux = {0:'pwl-bdm-opt'}
+#auxiliaryVariables=[pointGauges,lineGauges]
+auxiliaryVariables = ct.domain.auxiliaryVariables['twp']+[ct.v_output]

--- a/2d/sediment/strip_sediment/twp_navier_stokes_p.py
+++ b/2d/sediment/strip_sediment/twp_navier_stokes_p.py
@@ -1,0 +1,129 @@
+from proteus import *
+from proteus.default_p import *
+from tank import *
+from proteus.mprans import RANS3PF
+from proteus import Context
+
+ct = Context.get()
+
+LevelModelType = RANS3PF.LevelModel
+
+coefficients = RANS3PF.Coefficients(epsFact=epsFact_viscosity,
+                                    sigma=0.0,
+                                    rho_0 = rho_0,
+                                    nu_0 = nu_0,
+                                    rho_1 = rho_1,
+                                    nu_1 = nu_1,
+                                    g=g,
+                                    nd=nd,
+                                    ME_model=ct.V_model,
+                                    PRESSURE_model=ct.P_model,
+                                    SED_model=ct.SED_model,
+                                    VOF_model=ct.VOF_model,
+                                    VOS_model=ct.VOS_model,
+                                    LS_model=ct.LS_model,
+                                    Closure_0_model=ct.K_model,
+                                    Closure_1_model=ct.EPS_model,
+                                    epsFact_density=epsFact_density,
+                                    stokes=False,
+                                    useVF=useVF,
+                                    useRBLES=useRBLES,
+                                    useMetrics=useMetrics,
+                                    eb_adjoint_sigma=1.0,
+                                    eb_penalty_constant=weak_bc_penalty_constant,
+                                    forceStrongDirichlet=ns_forceStrongDirichlet,
+                                    turbulenceClosureModel=ns_closure,
+                                    movingDomain=movingDomain,
+                                    dragAlpha=dragAlpha,
+                                    PSTAB=ct.opts.PSTAB,
+                                    aDarcy = sedClosure.aDarcy,
+                                    betaForch = sedClosure.betaForch,
+                                    grain = sedClosure.grain,
+                                    packFraction = sedClosure.packFraction,
+                                    maxFraction = sedClosure.maxFraction,
+                                    frFraction = sedClosure.frFraction,
+                                    sigmaC = sedClosure.sigmaC,
+                                    C3e = sedClosure.C3e,
+                                    C4e = sedClosure.C4e,
+                                    eR = sedClosure.eR,
+                                    fContact = sedClosure.fContact,
+                                    mContact = sedClosure.mContact,
+                                    nContact = sedClosure.nContact,
+                                    angFriction = sedClosure.angFriction,
+                                    vos_function = ct.vos_function,
+                                    vos_limiter = ct.sedClosure.vos_limiter,
+                                    mu_fr_limiter = ct.sedClosure.mu_fr_limiter,
+                                    )
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].u_dirichlet.init_cython(),
+                       1: lambda x, flag: domain.bc[flag].v_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].u_advective.init_cython(),
+                                   1: lambda x, flag: domain.bc[flag].v_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {0: lambda x, flag: domain.bc[flag].u_diffusive.init_cython()},
+                                   1: {1: lambda x, flag: domain.bc[flag].v_diffusive.init_cython()}}
+
+if nd == 3:
+    dirichletConditions[2] = lambda x, flag: domain.bc[flag].w_dirichlet.init_cython()
+    advectiveFluxBoundaryConditions[2] = lambda x, flag: domain.bc[flag].w_advective.init_cython()
+    diffusiveFluxBoundaryConditions[2] = {2: lambda x, flag: domain.bc[flag].w_diffusive.init_cython()}
+
+class AtRest:
+    def __init__(self):
+        pass
+    def uOfXT(self,x,t):
+        return 0.0
+
+
+smoothing = 3*he
+
+
+class U_IC:
+
+
+    def uOfXT(self,x,t):
+        if ct.signedDistance(x) <= -0.28:
+            H = 1
+            speed = 0
+        elif -0.278 < ct.signedDistance(x) < -0.28 + smoothing:
+            H = 1-(smoothedHeaviside(smoothing/2. , ct.signedDistance(x)+0.28 - smoothing/2.))
+            speed = ct.opts.inflow_vel
+
+        elif  (ct.signedDistance(x) <= 0): 
+        #and ct.signedDistance(x)>= -0.27+smoothing):
+            H = 0
+            speed = ct.opts.inflow_vel
+        
+        elif 0 < ct.signedDistance(x) <= smoothing:
+            H = smoothedHeaviside(smoothing/2. , ct.signedDistance(x) - smoothing/2.)
+            speed = ct.opts.inflow_vel
+        else:
+            H = 1
+            speed = 0
+        
+        u = H * 0.0 + (1-H)*speed
+
+        return u
+
+
+class V_IC:
+    def uOfXT(self,x,t):
+                
+        v = 0.0
+
+        return v
+
+
+
+
+#if ct.opts.current:
+#    initialConditions = {0: U_IC(),
+#                         1: V_IC()}
+#
+#else:    
+#    initialConditions = {0:AtRest(),
+#                         1:AtRest()}
+
+initialConditions = {0:AtRest(),
+                     1:AtRest()}

--- a/2d/sediment/strip_sediment/vof_n.py
+++ b/2d/sediment/strip_sediment/vof_n.py
@@ -1,0 +1,77 @@
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import vof_p as physics
+from proteus.mprans import VOF3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+# time stepping
+runCFL = ct.runCFL
+timeIntegration = TimeIntegration.BackwardEuler_cfl
+stepController  = StepControl.Min_dt_controller
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = VOF3P.NumericalFlux
+conservativeFlux  = None
+subgridError      = VOF3P.SubgridError(coefficients=physics.coefficients,nd=nd)
+shockCapturing    = VOF3P.ShockCapturing(physics.coefficients,nd,shockCapturingFactor=ct.vof_shockCapturingFactor,lag=ct.vof_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.Newton
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'vof_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'r-true'
+
+tolFac      = 0.0
+nl_atol_res = ct.vof_nl_atol_res
+
+linTolFac   = 0.0
+l_atol_res = 0.1*ct.vof_nl_atol_res
+
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+
+auxiliaryVariables = ct.domain.auxiliaryVariables['vof']

--- a/2d/sediment/strip_sediment/vof_p.py
+++ b/2d/sediment/strip_sediment/vof_p.py
@@ -1,0 +1,39 @@
+from proteus.default_p import *
+from proteus.ctransportCoefficients import smoothedHeaviside
+from proteus.mprans import VOF3P
+from proteus import Context
+
+ct = Context.get()
+domain = ct.domain
+nd = domain.nd
+mesh = domain.MeshOptions
+
+
+genMesh = mesh.genMesh
+movingDomain = ct.movingDomain
+T = ct.T
+LevelModelType = VOF3P.LevelModel
+
+coefficients = VOF3P.Coefficients(LS_model=ct.LS_model,
+                                  V_model=ct.V_model,
+                                  RD_model=ct.RD_model,
+                                  ME_model=ct.VOF_model,
+                                  VOS_model=ct.VOS_model,
+                                  checkMass=True,
+                                  useMetrics=ct.useMetrics,
+                                  epsFact=ct.epsFact_vof,
+                                  sc_uref=ct.vof_sc_uref,
+                                  sc_beta=ct.vof_sc_beta,
+                                  movingDomain=ct.movingDomain)
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].vof_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].vof_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {}}
+
+class VF_IC:
+    def uOfXT(self, x, t):
+        return smoothedHeaviside(ct.epsFact_consrv_heaviside*mesh.he,x[nd-1]-ct.waterLevel)
+
+initialConditions = {0: VF_IC()}

--- a/2d/sediment/strip_sediment/vos_n.py
+++ b/2d/sediment/strip_sediment/vos_n.py
@@ -1,0 +1,81 @@
+from proteus import StepControl
+from proteus.default_n import *
+from proteus import (StepControl,
+                     TimeIntegration,
+                     NonlinearSolvers,
+                     LinearSolvers,
+                     LinearAlgebraTools)
+import vof_p as physics
+from proteus import Context
+from proteus.mprans import VOS3P
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+
+# time stepping
+runCFL = ct.runCFL
+timeIntegration = VOS3P.RKEV#BackwardEuler_cfl
+stepController  = StepControl.Min_dt_controller
+
+# mesh options
+nLevels = ct.nLevels
+parallelPartitioningType = mesh.parallelPartitioningType
+nLayersOfOverlapForParallel = mesh.nLayersOfOverlapForParallel
+restrictFineSolutionToAllMeshes = mesh.restrictFineSolutionToAllMeshes
+triangleOptions = mesh.triangleOptions
+
+
+
+elementQuadrature = ct.elementQuadrature
+elementBoundaryQuadrature = ct.elementBoundaryQuadrature
+
+
+femSpaces = {0:ct.basis}
+
+massLumping       = False
+numericalFluxType = VOS3P.NumericalFlux
+conservativeFlux  = None
+subgridError      = VOS3P.SubgridError(coefficients=physics.coefficients,nd=nd)
+shockCapturing    = VOS3P.ShockCapturing(physics.coefficients,nd,shockCapturingFactor=ct.vos_shockCapturingFactor,lag=ct.vos_lag_shockCapturing)
+
+fullNewtonFlag = True
+multilevelNonlinearSolver = NonlinearSolvers.Newton
+levelNonlinearSolver      = NonlinearSolvers.ExplicitLumpedMassMatrix
+
+nonlinearSmoother = None
+linearSmoother    = None
+
+matrix = LinearAlgebraTools.SparseMatrix
+
+if ct.useOldPETSc:
+    multilevelLinearSolver = LinearSolvers.PETSc
+    levelLinearSolver      = LinearSolvers.PETSc
+else:
+    multilevelLinearSolver = LinearSolvers.KSP_petsc4py
+    levelLinearSolver      = LinearSolvers.KSP_petsc4py
+
+if ct.useSuperlu:
+    multilevelLinearSolver = LinearSolvers.LU
+    levelLinearSolver      = LinearSolvers.LU
+
+linear_solver_options_prefix = 'vos_'
+nonlinearSolverConvergenceTest = 'rits'
+levelNonlinearSolverConvergenceTest = 'rits'
+linearSolverConvergenceTest         = 'r-true'
+
+tolFac      = 0.0
+nl_atol_res = ct.vos_nl_atol_res
+
+linTolFac   = 0.0
+l_atol_res = 0.1*ct.vos_nl_atol_res
+
+useEisenstatWalker = False
+
+maxNonlinearIts = 50
+maxLineSearches = 0
+
+#auxiliaryVariables = ct.domain.auxiliaryVariables['vos']
+auxiliaryVariables = ct.domain.auxiliaryVariables['vos']+[ct.vos_output]

--- a/2d/sediment/strip_sediment/vos_p.py
+++ b/2d/sediment/strip_sediment/vos_p.py
@@ -1,0 +1,40 @@
+from proteus import StepControl
+from proteus.default_p import *
+from proteus.ctransportCoefficients import smoothedHeaviside
+from proteus.mprans import VOS3P
+from proteus import Context
+from proteus import *
+
+ct = Context.get()
+domain = ct.domain
+nd = ct.domain.nd
+mesh = domain.MeshOptions
+
+LevelModelType = VOS3P.LevelModel
+
+coefficients = VOS3P.Coefficients(V_model=ct.V_model,
+                                  SED_model=ct.SED_model,
+                                  ME_model=ct.VOS_model,
+                                  checkMass=False,
+                                  useMetrics=ct.useMetrics,
+                                  epsFact=ct.epsFact_vos,
+                                  sc_uref=ct.vos_sc_uref,
+                                  sc_beta=ct.vos_sc_beta,
+                                  movingDomain=ct.movingDomain,
+                                  vos_function=ct.vos_function,
+                                  global_max_u=ct.opts.maxFraction,
+                                  STABILIZATION_TYPE=4,
+                                  LUMPED_MASS_MATRIX=True,
+                                  cE = 1.,
+                                  cK=0.
+                                  
+                                  )
+
+dirichletConditions = {0: lambda x, flag: domain.bc[flag].vos_dirichlet.init_cython()}
+
+advectiveFluxBoundaryConditions = {0: lambda x, flag: domain.bc[flag].vos_advective.init_cython()}
+
+diffusiveFluxBoundaryConditions = {0: {}}
+
+
+initialConditions  = {0:ct.Suspension}


### PR DESCRIPTION
Branched off of master and copied the sediment cases from gco_sed due to so many conflicts between gco_sed and master

1. Getting the solver error in sediment_erosion case, as discussed over Slack
2. Started getting an assertion error in the friction angle case when running with mpi **
3. Pipe scour case is running, but I'm not 100% sure of the parameters

** The assertion error:
```
Traceback (most recent call last):
  File "/home/breizh/proteus/linux2/bin/parun", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/home/breizh/proteus/scripts/parun", line 618, in <module>
    runName + '_init_prof')
  File "/home/breizh/proteus/proteus/Profiling.py", line 198, in __call__
    return func(*func_args, **func_kwargs)
  File "/home/breizh/proteus/proteus/NumericalSolution.py", line 613, in __init__
    self.allocateModels()
  File "/home/breizh/proteus/proteus/NumericalSolution.py", line 690, in allocateModels
    OneLevelTransportType=p.LevelModelType)
  File "/home/breizh/proteus/proteus/Transport.py", line 6147, in __init__
    PhiSpaceTypeDict=phiSpaces)
  File "/home/breizh/proteus/proteus/Transport.py", line 6404, in initialize
    options.levelLinearSolver == KSP_petsc4py), "Must use KSP_petsc4py in parallel"
AssertionError: Must use KSP_petsc4py in parallel

```
The only difference in the input file was switching hard-coded inputs to in the Hsu sed closure function to context options and removing some extra blank lines (e.g.: using only 1 blank line between blocks vs 4 or 5)