### PR TITLE
Make air-water-vv tests compatible with python3

### DIFF
--- a/2d/benchmarks/dambreak_with_obstacle/dambreak_with_obstacle.py
+++ b/2d/benchmarks/dambreak_with_obstacle/dambreak_with_obstacle.py
@@ -167,7 +167,7 @@ m.vof.index = 1
 m.ncls.index = 2
 m.rdls.index = 3
 m.mcorr.index = 4
-m.rdls.p.CoefficientsOptions.epsFact=0.75
+m.rdls.p.coefficients.epsFact=0.75
 #m.rans2p.p.CoefficientsOptions.useVF=0.
 
 #Assemble domain

--- a/2d/caissonBreakwater/sliding/tank.py
+++ b/2d/caissonBreakwater/sliding/tank.py
@@ -629,15 +629,15 @@ useVF = opts.useVF # used in the smoothing functions as (1.0-useVF)*smoothedHeav
 
 # Input checks
 if spaceOrder not in [1,2]:
-    print "INVALID: spaceOrder" + spaceOrder
+    print("INVALID: spaceOrder" + spaceOrder)
     sys.exit()
 
 if useRBLES not in [0.0, 1.0]:
-    print "INVALID: useRBLES" + useRBLES
+    print("INVALID: useRBLES" + useRBLES)
     sys.exit()
 
 if useMetrics not in [0.0, 1.0]:
-    print "INVALID: useMetrics"
+    print("INVALID: useMetrics")
     sys.exit()
 
 #  Discretization
@@ -645,22 +645,22 @@ nd = 2
 if spaceOrder == 1:
     hFactor=1.0
     if useHex:
-	 basis=C0_AffineLinearOnCubeWithNodalBasis
-         elementQuadrature = CubeGaussQuadrature(nd,3)
-         elementBoundaryQuadrature = CubeGaussQuadrature(nd-1,3)
+        basis=C0_AffineLinearOnCubeWithNodalBasis
+        elementQuadrature = CubeGaussQuadrature(nd,3)
+        elementBoundaryQuadrature = CubeGaussQuadrature(nd-1,3)
     else:
-    	 basis=C0_AffineLinearOnSimplexWithNodalBasis
-         elementQuadrature = SimplexGaussQuadrature(nd,3)
-         elementBoundaryQuadrature = SimplexGaussQuadrature(nd-1,3)
-         #elementBoundaryQuadrature = SimplexLobattoQuadrature(nd-1,1)
+        basis=C0_AffineLinearOnSimplexWithNodalBasis
+        elementQuadrature = SimplexGaussQuadrature(nd,3)
+        elementBoundaryQuadrature = SimplexGaussQuadrature(nd-1,3)
+        #elementBoundaryQuadrature = SimplexLobattoQuadrature(nd-1,1)
 elif spaceOrder == 2:
     hFactor=0.5
     if useHex:
-	basis=C0_AffineLagrangeOnCubeWithNodalBasis
+        basis=C0_AffineLagrangeOnCubeWithNodalBasis
         elementQuadrature = CubeGaussQuadrature(nd,4)
         elementBoundaryQuadrature = CubeGaussQuadrature(nd-1,4)
     else:
-	basis=C0_AffineQuadraticOnSimplexWithNodalBasis
+        basis=C0_AffineQuadraticOnSimplexWithNodalBasis
         elementQuadrature = SimplexGaussQuadrature(nd,4)
         elementBoundaryQuadrature = SimplexGaussQuadrature(nd-1,4)
 

--- a/2d/caissonBreakwater/sliding/tank_so.py
+++ b/2d/caissonBreakwater/sliding/tank_so.py
@@ -14,14 +14,14 @@ if '_so.py' in name_so[-6:]:
 elif '_so.pyc' in name_so[-7:]:
     name = name_so[:-7]
 else:
-    raise NameError, 'Split operator module must end with "_so.py"'
+    raise(NameError, 'Split operator module must end with "_so.py"')
 
 try:
     case = __import__(name)
     Context.setFromModule(case)
     ct = Context.get()
 except ImportError:
-    raise ImportError, str(name) + '.py not found'
+    raise(ImportError, str(name) + '.py not found')
 
 from proteus import BoundaryConditions
 

--- a/2d/floatingStructures/floating_caisson_BodyDynamics/floating_caisson2D.py
+++ b/2d/floatingStructures/floating_caisson_BodyDynamics/floating_caisson2D.py
@@ -305,7 +305,7 @@ params.physical.surf_tension_coeff = opts.sigma_01
 
 # ---  index in order of
 m = params.Models
-m.rdls.p.CoefficientsOptions.epsFact=0.75
+m.rdls.p.coefficients.epsFact=0.75
 
 m.moveMeshElastic.index=0
 m.rans2p.index = 1

--- a/2d/hydraulicStructures/crump_weir/crump_weir.py
+++ b/2d/hydraulicStructures/crump_weir/crump_weir.py
@@ -31,6 +31,7 @@ opts = Context.Options([
     ("gauge_dx", 0.25, "Horizontal spacing of gauges/gauge columns in m"),
     # refinement
     ("refinement", 10, "Refinement level he = tank_dim[0] / float(4 * refinement - 1)"),
+    #for use when longer testing times are available ("refinement", 40, "Refinement level he = tank_dim[0] / float(4 * refinement - 1)"), 
     ("cfl", 0.75, "Target cfl"),
     ("variable_refine_borders", None, "List of vertical borders between "
                                     "refinement regions (include 0 and "

--- a/2d/hydraulicStructures/crump_weir/crump_weir.py
+++ b/2d/hydraulicStructures/crump_weir/crump_weir.py
@@ -30,7 +30,7 @@ opts = Context.Options([
     ("column_gauge_output", True, "Produce column gauge data"),
     ("gauge_dx", 0.25, "Horizontal spacing of gauges/gauge columns in m"),
     # refinement
-    ("refinement", 40, "Refinement level he = tank_dim[0] / float(4 * refinement - 1)"),
+    ("refinement", 10, "Refinement level he = tank_dim[0] / float(4 * refinement - 1)"),
     ("cfl", 0.75, "Target cfl"),
     ("variable_refine_borders", None, "List of vertical borders between "
                                     "refinement regions (include 0 and "

--- a/2d/hydraulicStructures/crump_weir/crump_weir_so.py
+++ b/2d/hydraulicStructures/crump_weir/crump_weir_so.py
@@ -12,14 +12,14 @@ if '_so.py' in name_so[-6:]:
 elif '_so.pyc' in name_so[-7:]:
     name = name_so[:-7]
 else:
-    raise NameError, 'Split operator module must end with "_so.py"'
+    raise(NameError, 'Split operator module must end with "_so.py"')
 
 try:
     case = __import__(name)
     Context.setFromModule(case)
     ct = Context.get()
 except ImportError:
-    raise ImportError, str(name) + '.py not found'
+    raise(ImportError, str(name) + '.py not found')
 
 if ct.useOnlyVF:
     pnList = [("twp_navier_stokes_p", "twp_navier_stokes_n"),

--- a/2d/hydraulicStructures/sluice_gate/sluice_gate.py
+++ b/2d/hydraulicStructures/sluice_gate/sluice_gate.py
@@ -33,7 +33,8 @@ opts = Context.Options([
     ("gauge_dx", 0.1, "Horizontal spacing of gauges/gauge columns in m"),
     ("point_gauge_y", 0.09, "Height of point gauge placement in m"),
     # refinement
-    ("refinement", 25, "Refinement level he = tank_dim[0]/(4*refinement-1)"),
+    # use for later testing ("refinement", 25, "Refinement level he = tank_dim[0]/(4*refinement-1)"), 
+    ("refinement", 5, "Refinement level he = tank_dim[0]/(4*refinement-1)"), 
     ("cfl", 0.75, "Target cfl"),
     ("variable_refine_borders", None, "List of vertical borders between "
                                       "refinement regions (include 0 and "
@@ -101,13 +102,13 @@ timeDiscretization='be'  #'vbdf'#'be','flcbdf'
 applyCorrection = True
 # ----- INPUT CHECKS ----- #
 if spaceOrder not in [1,2]:
-    raise ValueError("INVALID: spaceOrder(" + str(spaceOrder) + ")")
+    raise(ValueError("INVALID: spaceOrder(" + str(spaceOrder) + ")"))
 
 if useRBLES not in [0.0, 1.0]:
-    raise ValueError("INVALID: useRBLES(" + str(useRBLES) + ")")
+    raise(ValueError("INVALID: useRBLES(" + str(useRBLES) + ")"))
 
 if useMetrics not in [0.0, 1.0]:
-    raise ValueError("INVALID: useMetrics(" + str(useMetrics) + ")")
+    raise(ValueError("INVALID: useMetrics(" + str(useMetrics) + ")"))
 
 # ----- DISCRETIZATION ----- #
 

--- a/2d/hydraulicStructures/sluice_gate/sluice_gate_so.py
+++ b/2d/hydraulicStructures/sluice_gate/sluice_gate_so.py
@@ -12,14 +12,14 @@ if '_so.py' in name_so[-6:]:
 elif '_so.pyc' in name_so[-7:]:
     name = name_so[:-7]
 else:
-    raise NameError, 'Split operator module must end with "_so.py"'
+    raise(NameError, 'Split operator module must end with "_so.py"')
 
 try:
     case = __import__(name)
     Context.setFromModule(case)
     ct = Context.get()
 except ImportError:
-    raise ImportError, str(name) + '.py not found'
+    raise(ImportError, str(name) + '.py not found')
 
 
 if ct.useOnlyVF:

--- a/Tests/1st_set/test_crump_weir.py
+++ b/Tests/1st_set/test_crump_weir.py
@@ -87,15 +87,15 @@ class TestCrumpWeirTetgen(TestTools.AirWaterVVTest):
             while i < len(all):
                 if i < len(all)-1:
                     if all[i+1][0]!='-':
-                        print "setting ", all[i].strip(), all[i+1]
+                        print("setting ", all[i].strip(), all[i+1])
                         OptDB.setValue(all[i].strip('-'),all[i+1])
                         i=i+2
                     else:
-                        print "setting ", all[i].strip(), "True"
+                        print("setting ", all[i].strip(), "True")
                         OptDB.setValue(all[i].strip('-'),True)
                         i=i+1
                 else:
-                    print "setting ", all[i].strip(), "True"
+                    print("setting ", all[i].strip(), "True")
                     OptDB.setValue(all[i].strip('-'),True)
                     i=i+1
         so.tnList=[0.0,0.001,0.011]            

--- a/Tests/1st_set/test_dambreak_Colagrossi.py
+++ b/Tests/1st_set/test_dambreak_Colagrossi.py
@@ -11,12 +11,13 @@ import tables
 import collections as cll
 import csv
 from proteus.test_utils import TestTools
+import subprocess
 
 from proteus.defaults import (load_physics as load_p,
                               load_numerics as load_n,
                               load_system as load_so)
 
-modulepath = os.path.join(os.path.dirname(os.path.abspath(__file__)),'../../2d/benchmarks/dambreak_Colagrossi')
+modulepath = os.path.join(os.path.dirname(os.path.abspath(__file__)),'../../2d/benchmarks/dambreak/')
 petsc_options = os.path.join(os.path.dirname(os.path.abspath(__file__)),"../../inputTemplates/petsc.options.asm")
 
 
@@ -67,50 +68,52 @@ class TestDambreakCollagrossiTetgen(TestTools.AirWaterVVTest):
     
 
 
-    
+    #@pytest.mark.skip(reason="Need to convert to TPF")
     def test_run(self):
-        from petsc4py import PETSc
-        pList = []
-        nList = []
-        so = load_so('dambreak_Colagrossi_so',modulepath)
-        for (p,n) in so.pnList:
-            pList.append(load_p(p,modulepath))
-            nList.append(load_n(n,modulepath))
-            if pList[-1].name == None:
-                pList[-1].name = p
-        #so = dambreak_Colagrossi_so
-        so.name = "dambreak_Colagrossi"
-        if so.sList == []:
-            for i in range(len(so.pnList)):
-                s = default_s
-                so.sList.append(s)
-        Profiling.logLevel=7
-        Profiling.verbose=True
-        # PETSc solver configuration
-        OptDB = PETSc.Options()
-        with open(petsc_options) as f:
-            all = f.read().split()
-            i=0
-            while i < len(all):
-                if i < len(all)-1:
-                    if all[i+1][0]!='-':
-                        print "setting ", all[i].strip(), all[i+1]
-                        OptDB.setValue(all[i].strip('-'),all[i+1])
-                        i=i+2
-                    else:
-                        print "setting ", all[i].strip(), "True"
-                        OptDB.setValue(all[i].strip('-'),True)
-                        i=i+1
-                else:
-                    print "setting ", all[i].strip(), "True"
-                    OptDB.setValue(all[i].strip('-'),True)
-                    i=i+1
-        so.tnList=[0.0,0.001,0.011]            
-        #so.tnList=[0.0,0.001]+[0.001 + i*0.01 for i in range(1, int(round(0.03/0.01))+1)]            
-        ns = NumericalSolution.NS_base(so,pList,nList,so.sList,opts)
-        ns.calculateSolution('dambreak_Colagrossi')
+        #from petsc4py import PETSc
+        #pList = []
+        #nList = []
+        #so = load_so('dambreak_Colagrossi_so',modulepath)
+        #for (p,n) in so.pnList:
+        #    pList.append(load_p(p,modulepath))
+        #    nList.append(load_n(n,modulepath))
+        #    if pList[-1].name == None:
+        #        pList[-1].name = p
+        ##so = dambreak_Colagrossi_so
+        #so.name = "dambreak_Colagrossi"
+        #if so.sList == []:
+        #    for i in range(len(so.pnList)):
+        #        s = default_s
+        #        so.sList.append(s)
+        #Profiling.logLevel=7
+        #Profiling.verbose=True
+        ## PETSc solver configuration
+        #OptDB = PETSc.Options()
+        #with open(petsc_options) as f:
+        #    all = f.read().split()
+        #    i=0
+        #    while i < len(all):
+        #        if i < len(all)-1:
+        #            if all[i+1][0]!='-':
+        #                print ("setting ", all[i].strip(), all[i+1])
+        #                OptDB.setValue(all[i].strip('-'),all[i+1])
+        #                i=i+2
+        #            else:
+        #                print ("setting ", all[i].strip(), "True")
+        #                OptDB.setValue(all[i].strip('-'),True)
+        #                i=i+1
+        #        else:
+        #            print ("setting ", all[i].strip(), "True")
+        #            OptDB.setValue(all[i].strip('-'),True)
+        #            i=i+1
+        #so.tnList=[0.0,0.001,0.011]            
+        ##so.tnList=[0.0,0.001]+[0.001 + i*0.01 for i in range(1, int(round(0.03/0.01))+1)]            
+        #ns = NumericalSolution.NS_base(so,pList,nList,so.sList,opts)
+        #ns.calculateSolution('dambreak_Colagrossi')
 
-        
+        runCommand = "parun --TwoPhaseFlow --path " +modulepath+" -C \"duration=0.011\" dambreak.py"
+        subprocess.check_call(runCommand,shell=True)
+ 
         #def failed(filename,word):
         colagrossi_log= NumericResults.create_log('proteus.log')
 

--- a/Tests/1st_set/test_dambreak_Ubbink.py
+++ b/Tests/1st_set/test_dambreak_Ubbink.py
@@ -10,12 +10,13 @@ import numpy as np
 import collections as cll
 import csv
 from proteus.test_utils import TestTools
+import subprocess
 
 from proteus.defaults import (load_physics as load_p,
                               load_numerics as load_n,
                               load_system as load_so)
 
-modulepath = os.path.join(os.path.dirname(os.path.abspath(__file__)),'../../2d/benchmarks/dambreak_Ubbink')
+modulepath = os.path.join(os.path.dirname(os.path.abspath(__file__)),'../../2d/benchmarks/dambreak_with_obstacle')
 petsc_options = os.path.join(os.path.dirname(os.path.abspath(__file__)),"../../inputTemplates/petsc.options.asm")
 
 
@@ -64,48 +65,50 @@ class TestDambreakUbbinkTetgen(TestTools.AirWaterVVTest):
 
             
     def test_run(self):
-        from petsc4py import PETSc
-        pList = []
-        nList = []
-        so = load_so('dambreak_Ubbink_so',modulepath)
-        for (p,n) in so.pnList:
-            pList.append(load_p(p,modulepath))
-            nList.append(load_n(n,modulepath))
-            if pList[-1].name == None:
-                pList[-1].name = p
-        #so = dambreak_Ubbink_so
-        so.name = "dambreak_Ubbink"
-        if so.sList == []:
-            for i in range(len(so.pnList)):
-                s = default_s
-                so.sList.append(s)
-        Profiling.logLevel=7
-        Profiling.verbose=True
-        # PETSc solver configuration
-        OptDB = PETSc.Options()
-        with open(petsc_options) as f:
-            all = f.read().split()
-            i=0
-            while i < len(all):
-                if i < len(all)-1:
-                    if all[i+1][0]!='-':
-                        print "setting ", all[i].strip(), all[i+1]
-                        OptDB.setValue(all[i].strip('-'),all[i+1])
-                        i=i+2
-                    else:
-                        print "setting ", all[i].strip(), "True"
-                        OptDB.setValue(all[i].strip('-'),True)
-                        i=i+1
-                else:
-                    print "setting ", all[i].strip(), "True"
-                    OptDB.setValue(all[i].strip('-'),True)
-                    i=i+1
-        so.tnList=[0.0,0.001,0.011]            
-        #so.tnList=[0.0,0.001]+[0.001 + i*0.01 for i in range(1,int(round(0.03/0.01))+1)]            
-        ns = NumericalSolution.NS_base(so,pList,nList,so.sList,opts)
-        ns.calculateSolution('dambreak_Ubbink')
+        #from petsc4py import PETSc
+        #pList = []
+        #nList = []
+        #so = load_so('dambreak_Ubbink_so',modulepath)
+        #for (p,n) in so.pnList:
+        #    pList.append(load_p(p,modulepath))
+        #    nList.append(load_n(n,modulepath))
+        #    if pList[-1].name == None:
+        #        pList[-1].name = p
+        ##so = dambreak_Ubbink_so
+        #so.name = "dambreak_Ubbink"
+        #if so.sList == []:
+        #    for i in range(len(so.pnList)):
+        #        s = default_s
+        #        so.sList.append(s)
+        #Profiling.logLevel=7
+        #Profiling.verbose=True
+        ## PETSc solver configuration
+        #OptDB = PETSc.Options()
+        #with open(petsc_options) as f:
+        #    all = f.read().split()
+        #    i=0
+        #    while i < len(all):
+        #        if i < len(all)-1:
+        #            if all[i+1][0]!='-':
+        #                print ("setting ", all[i].strip(), all[i+1])
+        #                OptDB.setValue(all[i].strip('-'),all[i+1])
+        #                i=i+2
+        #            else:
+        #                print ("setting ", all[i].strip(), "True")
+        #                OptDB.setValue(all[i].strip('-'),True)
+        #                i=i+1
+        #        else:
+        #            print ("setting ", all[i].strip(), "True")
+        #            OptDB.setValue(all[i].strip('-'),True)
+        #            i=i+1
+        #so.tnList=[0.0,0.001,0.011]            
+        ##so.tnList=[0.0,0.001]+[0.001 + i*0.01 for i in range(1,int(round(0.03/0.01))+1)]            
+        #ns = NumericalSolution.NS_base(so,pList,nList,so.sList,opts)
+        #ns.calculateSolution('dambreak_Ubbink')
 
-        
+        runCommand = "parun --TwoPhaseFlow --path " +modulepath+" -C \"duration=0.011\" dambreak_with_obstacle.py"
+        subprocess.check_call(runCommand,shell=True)
+
         ubbink_log = NumericResults.create_log('proteus.log')
 
         text = ubbink_log.read()

--- a/Tests/1st_set/test_floating2D_BD.py
+++ b/Tests/1st_set/test_floating2D_BD.py
@@ -11,12 +11,13 @@ import csv
 from proteus.test_utils import TestTools
 #import AnalysisTools as at
 import math
+import subprocess
 
 from proteus.defaults import (load_physics as load_p,
                               load_numerics as load_n,
                               load_system as load_so)
 
-modulepath = os.path.join(os.path.dirname(os.path.abspath(__file__)),'../../2d/floatingStructures/floating_caisson_BodyDynamics')
+modulepath = os.path.join(os.path.dirname(os.path.abspath(__file__)),'../../2d/floatingStructures/floating_caisson_BodyDynamics/')
 petsc_options = os.path.join(os.path.dirname(os.path.abspath(__file__)),"../../inputTemplates/petsc.options.asm")
 
 
@@ -63,46 +64,48 @@ class TestFloatingCaissonBDTetgen(TestTools.AirWaterVVTest):
                 pass
             
     def test_run(self):
-        from petsc4py import PETSc
-        pList = []
-        nList = []
-        so = load_so('floating2D_BD_so',modulepath)
-        for (p,n) in so.pnList:
-            pList.append(load_p(p,modulepath))
-            nList.append(load_n(n,modulepath))
-            if pList[-1].name == None:
-                pList[-1].name = p
-        #so = floating2D_BD_so
-        so.name = "floating2D_BD"
-        if so.sList == []:
-            for i in range(len(so.pnList)):
-                s = default_s
-                so.sList.append(s)
-        Profiling.logLevel=7
-        Profiling.verbose=True
-        # PETSc solver configuration
-        OptDB = PETSc.Options()
-        with open(petsc_options) as f:
-            all = f.read().split()
-            i=0
-            while i < len(all):
-                if i < len(all)-1:
-                    if all[i+1][0]!='-':
-                        print "setting ", all[i].strip(), all[i+1]
-                        OptDB.setValue(all[i].strip('-'),all[i+1])
-                        i=i+2
-                    else:
-                        print "setting ", all[i].strip(), "True"
-                        OptDB.setValue(all[i].strip('-'),True)
-                        i=i+1
-                else:
-                    print "setting ", all[i].strip(), "True"
-                    OptDB.setValue(all[i].strip('-'),True)
-                    i=i+1
-        so.tnList=[0.0,0.001,0.011]            
-        #so.tnList=[0.0,0.001]+[0.001 + i*0.01 for i in range(1, int(round(0.03/0.01))+1)]            
-        ns = NumericalSolution.NS_base(so,pList,nList,so.sList,opts)
-        ns.calculateSolution('floating2D_BD')
+        #from petsc4py import PETSc
+        #pList = []
+        #nList = []
+        #so = load_so('floating2D_BD_so',modulepath)
+        #for (p,n) in so.pnList:
+        #    pList.append(load_p(p,modulepath))
+        #    nList.append(load_n(n,modulepath))
+        #    if pList[-1].name == None:
+        #        pList[-1].name = p
+        ##so = floating2D_BD_so
+        #so.name = "floating2D_BD"
+        #if so.sList == []:
+        #    for i in range(len(so.pnList)):
+        #        s = default_s
+        #        so.sList.append(s)
+        #Profiling.logLevel=7
+        #Profiling.verbose=True
+        ## PETSc solver configuration
+        #OptDB = PETSc.Options()
+        #with open(petsc_options) as f:
+        #    all = f.read().split()
+        #    i=0
+        #    while i < len(all):
+        #        if i < len(all)-1:
+        #            if all[i+1][0]!='-':
+        #                print ("setting ", all[i].strip(), all[i+1])
+        #                OptDB.setValue(all[i].strip('-'),all[i+1])
+        #                i=i+2
+        #            else:
+        #                print ("setting ", all[i].strip(), "True")
+        #                OptDB.setValue(all[i].strip('-'),True)
+        #                i=i+1
+        #        else:
+        #            print ("setting ", all[i].strip(), "True")
+        #            OptDB.setValue(all[i].strip('-'),True)
+        #            i=i+1
+        #so.tnList=[0.0,0.001,0.011]            
+        ##so.tnList=[0.0,0.001]+[0.001 + i*0.01 for i in range(1, int(round(0.03/0.01))+1)]            
+        #ns = NumericalSolution.NS_base(so,pList,nList,so.sList,opts)
+        #ns.calculateSolution('floating2D_BD')
+        runCommand = "parun --TwoPhaseFlow --path " +modulepath+" -C \"duration=0.011\" floating_caisson2D.py"
+        subprocess.check_call(runCommand,shell=True)
 
         floating_log = NumericResults.create_log('proteus.log')
 

--- a/Tests/1st_set/test_linearWaves.py
+++ b/Tests/1st_set/test_linearWaves.py
@@ -13,12 +13,13 @@ import csv
 from proteus.WaveTools import decompose_tseries
 from proteus.test_utils import TestTools
 #from AnalysisTools import readProbeFile,signalFilter,zeroCrossing,reflStat
+import subprocess
 
 from proteus.defaults import (load_physics as load_p,
                               load_numerics as load_n,
                               load_system as load_so)
 
-modulepath = os.path.join(os.path.dirname(os.path.abspath(__file__)),'../../2d/numericalTanks/linearWaves')
+modulepath = os.path.join(os.path.dirname(os.path.abspath(__file__)),'../../2d/numericalTanks/regularWaves/')
 petsc_options = os.path.join(os.path.dirname(os.path.abspath(__file__)),"../../inputTemplates/petsc.options.asm")
 
 
@@ -66,46 +67,48 @@ class TestLinearWavesTetgen(TestTools.AirWaterVVTest):
 
 
     def test_run(self):
-        from petsc4py import PETSc
-        pList = []
-        nList = []
-        so = load_so('linear_waves_so',modulepath)
-        for (p,n) in so.pnList:
-            pList.append(load_p(p,modulepath))
-            nList.append(load_n(n,modulepath))
-            if pList[-1].name == None:
-                pList[-1].name = p
-        so.name = "linear_waves"
-        if so.sList == []:
-            for i in range(len(so.pnList)):
-                s = default_s
-                so.sList.append(s)
-        Profiling.logLevel=7
-        Profiling.verbose=True
-        # PETSc solver configuration
-        OptDB = PETSc.Options()
-        with open(petsc_options) as f:
-            all = f.read().split()
-            i=0
-            while i < len(all):
-                if i < len(all)-1:
-                    if all[i+1][0]!='-':
-                        print "setting ", all[i].strip(), all[i+1]
-                        OptDB.setValue(all[i].strip('-'),all[i+1])
-                        i=i+2
-                    else:
-                        print "setting ", all[i].strip(), "True"
-                        OptDB.setValue(all[i].strip('-'),True)
-                        i=i+1
-                else:
-                    print "setting ", all[i].strip(), "True"
-                    OptDB.setValue(all[i].strip('-'),True)
-                    i=i+1
-        so.tnList=[0.0,0.001,0.011]            
-        #so.tnList=[0.0,0.001]+[0.001 + i*0.01 for i in range(1,int(round(0.03/0.01))+1)]            
-        ns = NumericalSolution.NS_base(so,pList,nList,so.sList,opts)
-        ns.calculateSolution('linear_waves')
-       
+        #from petsc4py import PETSc
+        #pList = []
+        #nList = []
+        #so = load_so('linear_waves_so',modulepath)
+        #for (p,n) in so.pnList:
+        #    pList.append(load_p(p,modulepath))
+        #    nList.append(load_n(n,modulepath))
+        #    if pList[-1].name == None:
+        #        pList[-1].name = p
+        #so.name = "linear_waves"
+        #if so.sList == []:
+        #    for i in range(len(so.pnList)):
+        #        s = default_s
+        #        so.sList.append(s)
+        #Profiling.logLevel=7
+        #Profiling.verbose=True
+        ## PETSc solver configuration
+        #OptDB = PETSc.Options()
+        #with open(petsc_options) as f:
+        #    all = f.read().split()
+        #    i=0
+        #    while i < len(all):
+        #        if i < len(all)-1:
+        #            if all[i+1][0]!='-':
+        #                print ("setting ", all[i].strip(), all[i+1])
+        #                OptDB.setValue(all[i].strip('-'),all[i+1])
+        #                i=i+2
+        #            else:
+        #                print ("setting ", all[i].strip(), "True")
+        #                OptDB.setValue(all[i].strip('-'),True)
+        #                i=i+1
+        #        else:
+        #            print ("setting ", all[i].strip(), "True")
+        #            OptDB.setValue(all[i].strip('-'),True)
+        #            i=i+1
+        #so.tnList=[0.0,0.001,0.011]            
+        ##so.tnList=[0.0,0.001]+[0.001 + i*0.01 for i in range(1,int(round(0.03/0.01))+1)]            
+        #ns = NumericalSolution.NS_base(so,pList,nList,so.sList,opts)
+        #ns.calculateSolution('linear_waves')
+        runCommand = "parun --TwoPhaseFlow --path " +modulepath+" -C \"Tend=0.011 waveType=\'Linear\'\" regular_waves.py"
+        subprocess.check_call(runCommand,shell=True)
+
         linear_log = NumericResults.create_log('proteus.log')
 
         text = linear_log.read()

--- a/Tests/1st_set/test_nonlinearWaves.py
+++ b/Tests/1st_set/test_nonlinearWaves.py
@@ -11,13 +11,14 @@ import numpy as np
 import collections as cll
 import csv
 from proteus.test_utils import TestTools
+import subprocess
 #from AnalysisTools import readProbeFile,signalFilter,zeroCrossing,reflStat
 
 from proteus.defaults import (load_physics as load_p,
                               load_numerics as load_n,
                               load_system as load_so)
 
-modulepath = os.path.join(os.path.dirname(os.path.abspath(__file__)),'../../2d/numericalTanks/nonlinearWaves')
+modulepath = os.path.join(os.path.dirname(os.path.abspath(__file__)),'../../2d/numericalTanks/regularWaves')
 petsc_options = os.path.join(os.path.dirname(os.path.abspath(__file__)),"../../inputTemplates/petsc.options.asm")
 
 class NumericResults:
@@ -66,46 +67,47 @@ class TestNonLinearWavesTetgen(TestTools.AirWaterVVTest):
 
             
     def test_run(self):
-        from petsc4py import PETSc
-        pList = []
-        nList = []
-        so = load_so('nonlinear_waves_so',modulepath)
-        for (p,n) in so.pnList:
-            pList.append(load_p(p,modulepath))
-            nList.append(load_n(n,modulepath))
-            if pList[-1].name == None:
-                pList[-1].name = p
-        so.name = "nonlinear_waves"
-        if so.sList == []:
-            for i in range(len(so.pnList)):
-                s = default_s
-                so.sList.append(s)
-        Profiling.logLevel=7
-        Profiling.verbose=True
-        # PETSc solver configuration
-        OptDB = PETSc.Options()
-        with open(petsc_options) as f:
-            all = f.read().split()
-            i=0
-            while i < len(all):
-                if i < len(all)-1:
-                    if all[i+1][0]!='-':
-                        print "setting ", all[i].strip(), all[i+1]
-                        OptDB.setValue(all[i].strip('-'),all[i+1])
-                        i=i+2
-                    else:
-                        print "setting ", all[i].strip(), "True"
-                        OptDB.setValue(all[i].strip('-'),True)
-                        i=i+1
-                else:
-                    print "setting ", all[i].strip(), "True"
-                    OptDB.setValue(all[i].strip('-'),True)
-                    i=i+1
-        so.tnList=[0.0,0.001,0.011]            
-        #so.tnList=[0.0,0.001]+[0.001 + i*0.01 for i in range(1,int(round(0.03/0.01))+1)]            
-        ns = NumericalSolution.NS_base(so,pList,nList,so.sList,opts)
-        ns.calculateSolution('nonlinear_waves')
-
+        #from petsc4py import PETSc
+        #pList = []
+        #nList = []
+        #so = load_so('nonlinear_waves_so',modulepath)
+        #for (p,n) in so.pnList:
+        #    pList.append(load_p(p,modulepath))
+        #    nList.append(load_n(n,modulepath))
+        #    if pList[-1].name == None:
+        #        pList[-1].name = p
+        #so.name = "nonlinear_waves"
+        #if so.sList == []:
+        #    for i in range(len(so.pnList)):
+        #        s = default_s
+        #        so.sList.append(s)
+        #Profiling.logLevel=7
+        #Profiling.verbose=True
+        ## PETSc solver configuration
+        #OptDB = PETSc.Options()
+        #with open(petsc_options) as f:
+        #    all = f.read().split()
+        #    i=0
+        #    while i < len(all):
+        #        if i < len(all)-1:
+        #            if all[i+1][0]!='-':
+        #                print ("setting ", all[i].strip(), all[i+1])
+        #                OptDB.setValue(all[i].strip('-'),all[i+1])
+        #                i=i+2
+        #            else:
+        #                print ("setting ", all[i].strip(), "True")
+        #                OptDB.setValue(all[i].strip('-'),True)
+        #                i=i+1
+        #        else:
+        #            print ("setting ", all[i].strip(), "True")
+        #            OptDB.setValue(all[i].strip('-'),True)
+        #            i=i+1
+        #so.tnList=[0.0,0.001,0.011]            
+        ##so.tnList=[0.0,0.001]+[0.001 + i*0.01 for i in range(1,int(round(0.03/0.01))+1)]            
+        #ns = NumericalSolution.NS_base(so,pList,nList,so.sList,opts)
+        #ns.calculateSolution('nonlinear_waves')
+        runCommand = "parun --TwoPhaseFlow --path " +modulepath+" -C \"Tend=0.011 waveType=\'Fenton\'\" regular_waves.py"
+        subprocess.check_call(runCommand,shell=True)
 
         non_linear_log = NumericResults.create_log('proteus.log')
 

--- a/Tests/2nd_set/test_oscillating_cylinder.py
+++ b/Tests/2nd_set/test_oscillating_cylinder.py
@@ -16,6 +16,7 @@ from proteus.test_utils import TestTools
 import math
 #import importlib
 from proteus import defaults
+import subprocess
 
 from proteus.defaults import (load_physics as load_p,
                               load_numerics as load_n,
@@ -71,47 +72,49 @@ class TestOscillatingCylinderTetgen(TestTools.AirWaterVVTest):
 
             
     def test_run(self):
-        from petsc4py import PETSc
-        pList = []
-        nList = []
-        so = load_so('tank_so',modulepath)
-        for (p,n) in so.pnList:
-            pList.append(load_p(p,modulepath))
-            nList.append(load_n(n,modulepath))
-            if pList[-1].name == None:
-                pList[-1].name = p
-        #so = tank_so
-        so.name = "tank"
-        if so.sList == []:
-            for i in range(len(so.pnList)):
-                s = default_s
-                so.sList.append(s)
-        Profiling.logLevel=7
-        Profiling.verbose=True
-        # PETSc solver configuration
-        OptDB = PETSc.Options()
-        with open(petsc_options) as f:
-            all = f.read().split()
-            i = 0
-            while i < len(all):
-                if i < len(all)-1:
-                    if all[i+1][0]!='-':
-                        print "setting", all[i].strip(),all[i+1]
-                        OptDB.setValue(all[i].strip('-'),all[i+1])
-                        i = i+2
-                    else:
-                        print "setting", all[i].strip(), "True"
-                        OptDB.setValue(all[i].strip('-'),True)
-                        i = i+1
-                else:
-                    print "setting", all[i].strip(), "True"
-                    OptDB.setValue(all[i].strip('-'),True)
-                    i= i+1
-        so.tnList=[0.0,0.001,0.011]            
-        #so.tnList=[0.0,0.001]+[0.001 + i*0.01 for i in range(1,int(round(0.03/0.01))+1)]            
-        ns = NumericalSolution.NS_base(so,pList,nList,so.sList,opts)
-        ns.calculateSolution('tank')
+        #from petsc4py import PETSc
+        #pList = []
+        #nList = []
+        #so = load_so('tank_so',modulepath)
+        #for (p,n) in so.pnList:
+        #    pList.append(load_p(p,modulepath))
+        #    nList.append(load_n(n,modulepath))
+        #    if pList[-1].name == None:
+        #        pList[-1].name = p
+        ##so = tank_so
+        #so.name = "tank"
+        #if so.sList == []:
+        #    for i in range(len(so.pnList)):
+        #        s = default_s
+        #        so.sList.append(s)
+        #Profiling.logLevel=7
+        #Profiling.verbose=True
+        ## PETSc solver configuration
+        #OptDB = PETSc.Options()
+        #with open(petsc_options) as f:
+        #    all = f.read().split()
+        #    i = 0
+        #    while i < len(all):
+        #        if i < len(all)-1:
+        #            if all[i+1][0]!='-':
+        #                print("setting", all[i].strip(),all[i+1])
+        #                OptDB.setValue(all[i].strip('-'),all[i+1])
+        #                i = i+2
+        #            else:
+        #                print("setting", all[i].strip(), "True")
+        #                OptDB.setValue(all[i].strip('-'),True)
+        #                i = i+1
+        #        else:
+        #            print("setting", all[i].strip(), "True")
+        #            OptDB.setValue(all[i].strip('-'),True)
+        #            i= i+1
+        #so.tnList=[0.0,0.001,0.011]            
+        ##so.tnList=[0.0,0.001]+[0.001 + i*0.01 for i in range(1,int(round(0.03/0.01))+1)]            
+        #ns = NumericalSolution.NS_base(so,pList,nList,so.sList,opts)
+        #ns.calculateSolution('tank')
 
+        runCommand = "parun --TwoPhaseFlow --path " +modulepath+" -C \"Tend=0.011\" oscillating_cylinder.py"
+        subprocess.check_call(runCommand,shell=True)
         
         oscillating_log = NumericResults.create_log('proteus.log')
 

--- a/Tests/2nd_set/test_quiescent_water.py
+++ b/Tests/2nd_set/test_quiescent_water.py
@@ -11,12 +11,13 @@ import numpy as np
 import collections as cll
 import csv
 from proteus.test_utils import TestTools
+import subprocess
 
 from proteus.defaults import (load_physics as load_p,
                               load_numerics as load_n,
                               load_system as load_so)
 
-modulepath = os.path.join(os.path.dirname(os.path.abspath(__file__)),'../../2d/benchmarks/quiescent_water_probe_benchmark')
+modulepath = os.path.join(os.path.dirname(os.path.abspath(__file__)),'../../2d/benchmarks/wavesloshing')
 petsc_options = os.path.join(os.path.dirname(os.path.abspath(__file__)),"../../inputTemplates/petsc.options.asm")
 
 
@@ -65,48 +66,50 @@ class TestQuiescentWaterTetgen(TestTools.AirWaterVVTest):
 
             
     def test_run(self):
-        from petsc4py import PETSc
-        pList = []
-        nList = []
-        so = load_so('quiescent_water_test_gauges_so',modulepath)
-        for (p,n) in so.pnList:
-            pList.append(load_p(p,modulepath))
-            nList.append(load_n(n,modulepath))
-            if pList[-1].name == None:
-                pList[-1].name = p
-        #so = quiescent_water_test_gauges_so
-        so.name = "quiescent_water_test_gauges"
-        if so.sList == []:
-            for i in range(len(so.pnList)):
-                s = default_s
-                so.sList.append(s)
-        Profiling.logLevel=7
-        Profiling.verbose=True
-        # PETSc solver configuration
-        OptDB = PETSc.Options()
-        with open(petsc_options) as f:
-            all = f.read().split()
-            i=0
-            while i < len(all):
-                if i < len(all)-1:
-                    if all[i+1][0]!='-':
-                        print "setting ", all[i].strip(), all[i+1]
-                        OptDB.setValue(all[i].strip('-'),all[i+1])
-                        i=i+2
-                    else:
-                        print "setting ", all[i].strip(), "True"
-                        OptDB.setValue(all[i].strip('-'),True)
-                        i=i+1
-                else:
-                    print "setting ", all[i].strip(), "True"
-                    OptDB.setValue(all[i].strip('-'),True)
-                    i=i+1
-        so.tnList=[0.0,0.001,0.011]            
-        #so.tnList=[0.0,0.001]+[0.001 + i*0.01 for i in range(1,int(round(0.03/0.01))+1)]            
-        ns = NumericalSolution.NS_base(so,pList,nList,so.sList,opts)
-        ns.calculateSolution('quiescent_water_test_gauges')
+        #from petsc4py import PETSc
+        #pList = []
+        #nList = []
+        #so = load_so('quiescent_water_test_gauges_so',modulepath)
+        #for (p,n) in so.pnList:
+        #    pList.append(load_p(p,modulepath))
+        #    nList.append(load_n(n,modulepath))
+        #    if pList[-1].name == None:
+        #        pList[-1].name = p
+        ##so = quiescent_water_test_gauges_so
+        #so.name = "quiescent_water_test_gauges"
+        #if so.sList == []:
+        #    for i in range(len(so.pnList)):
+        #        s = default_s
+        #        so.sList.append(s)
+        #Profiling.logLevel=7
+        #Profiling.verbose=True
+        ## PETSc solver configuration
+        #OptDB = PETSc.Options()
+        #with open(petsc_options) as f:
+        #    all = f.read().split()
+        #    i=0
+        #    while i < len(all):
+        #        if i < len(all)-1:
+        #            if all[i+1][0]!='-':
+        #                print "setting ", all[i].strip(), all[i+1]
+        #                OptDB.setValue(all[i].strip('-'),all[i+1])
+        #                i=i+2
+        #            else:
+        #                print "setting ", all[i].strip(), "True"
+        #                OptDB.setValue(all[i].strip('-'),True)
+        #                i=i+1
+        #        else:
+        #            print "setting ", all[i].strip(), "True"
+        #            OptDB.setValue(all[i].strip('-'),True)
+        #            i=i+1
+        #so.tnList=[0.0,0.001,0.011]            
+        ##so.tnList=[0.0,0.001]+[0.001 + i*0.01 for i in range(1,int(round(0.03/0.01))+1)]            
+        #ns = NumericalSolution.NS_base(so,pList,nList,so.sList,opts)
+        #ns.calculateSolution('quiescent_water_test_gauges')
         
-        
+        runCommand = "parun --TwoPhaseFlow --path " +modulepath+" -C \"T=0.011 amplitude=0.0 he=0.01\" wavesloshing.py"
+        subprocess.check_call(runCommand,shell=True)
+
         quiescent_log = NumericResults.create_log('proteus.log')
 
         text = quiescent_log.read()

--- a/Tests/2nd_set/test_randomWaves.py
+++ b/Tests/2nd_set/test_randomWaves.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import os
-os.chdir(os.path.join(os.path.dirname(os.path.abspath(__file__)),'../../2d/numericalTanks/randomWaves'))
+#os.chdir(os.path.join(os.path.dirname(os.path.abspath(__file__)),'../../2d/numericalTanks/randomWaves'))
 
 import pytest
 from proteus.iproteus import *
@@ -13,6 +13,7 @@ import collections as cll
 import csv
 from proteus.test_utils import TestTools
 #from AnalysisTools import readProbeFile,signalFilter,zeroCrossing,reflStat
+import subprocess
 
 from proteus.defaults import (load_physics as load_p,
                               load_numerics as load_n,
@@ -68,47 +69,48 @@ class TestRandomWavesTetgen(TestTools.AirWaterVVTest):
 
             
     def test_run(self):
-        from petsc4py import PETSc
-        pList = []
-        nList = []
-        so = load_so('random_waves_so',modulepath)
-        for (p,n) in so.pnList:
-            pList.append(load_p(p,modulepath))
-            nList.append(load_n(n,modulepath))
-            if pList[-1].name == None:
-                pList[-1].name = p
-        #so = random_waves_so
-        so.name = "random_waves"
-        if so.sList == []:
-            for i in range(len(so.pnList)):
-                s = default_s
-                so.sList.append(s)
-        Profiling.logLevel=7
-        Profiling.verbose=True
-        # PETSc solver configuration
-        OptDB = PETSc.Options()
-        with open(petsc_options) as f:
-            all = f.read().split()
-            i=0
-            while i < len(all):
-                if i < len(all)-1:
-                    if all[i+1][0]!='-':
-                        print "setting ", all[i].strip(), all[i+1]
-                        OptDB.setValue(all[i].strip('-'),all[i+1])
-                        i=i+2
-                    else:
-                        print "setting ", all[i].strip(), "True"
-                        OptDB.setValue(all[i].strip('-'),True)
-                        i=i+1
-                else:
-                    print "setting ", all[i].strip(), "True"
-                    OptDB.setValue(all[i].strip('-'),True)
-                    i=i+1
-        so.tnList=[0.0,0.001,0.011]            
-        #so.tnList=[0.0,0.001]+[0.001 + i*0.01 for i in range(1,int(round(0.03/0.01))+1)]            
-        ns = NumericalSolution.NS_base(so,pList,nList,so.sList,opts)
-        ns.calculateSolution('random_waves')
-
+        #from petsc4py import PETSc
+        #pList = []
+        #nList = []
+        #so = load_so('random_waves_so',modulepath)
+        #for (p,n) in so.pnList:
+        #    pList.append(load_p(p,modulepath))
+        #    nList.append(load_n(n,modulepath))
+        #    if pList[-1].name == None:
+        #        pList[-1].name = p
+        ##so = random_waves_so
+        #so.name = "random_waves"
+        #if so.sList == []:
+        #    for i in range(len(so.pnList)):
+        #        s = default_s
+        #        so.sList.append(s)
+        #Profiling.logLevel=7
+        #Profiling.verbose=True
+        ## PETSc solver configuration
+        #OptDB = PETSc.Options()
+        #with open(petsc_options) as f:
+        #    all = f.read().split()
+        #    i=0
+        #    while i < len(all):
+        #        if i < len(all)-1:
+        #            if all[i+1][0]!='-':
+        #                print "setting ", all[i].strip(), all[i+1]
+        #                OptDB.setValue(all[i].strip('-'),all[i+1])
+        #                i=i+2
+        #            else:
+        #                print "setting ", all[i].strip(), "True"
+        #                OptDB.setValue(all[i].strip('-'),True)
+        #                i=i+1
+        #        else:
+        #            print "setting ", all[i].strip(), "True"
+        #            OptDB.setValue(all[i].strip('-'),True)
+        #            i=i+1
+        #so.tnList=[0.0,0.001,0.011]            
+        ##so.tnList=[0.0,0.001]+[0.001 + i*0.01 for i in range(1,int(round(0.03/0.01))+1)]            
+        #ns = NumericalSolution.NS_base(so,pList,nList,so.sList,opts)
+        #ns.calculateSolution('random_waves')
+        runCommand = "parun --TwoPhaseFlow --path " +modulepath+" -C \"refinement_level=5 Ntotalwaves=40\" random_waves.py"
+        subprocess.check_call(runCommand,shell=True)
 
         random_log = NumericResults.create_log('proteus.log')
 

--- a/Tests/2nd_set/test_sliding_CB.py
+++ b/Tests/2nd_set/test_sliding_CB.py
@@ -94,15 +94,15 @@ class TestSlidingCaissonTetgen(TestTools.AirWaterVVTest):
             while i < len(all):
                 if i < len(all)-1:
                     if all[i+1][0]!='-':
-                        print "setting", all[i].strip(),all[i+1]
+                        print("setting ", all[i].strip(), all[i+1])
                         OptDB.setValue(all[i].strip('-'),all[i+1])
                         i=i+2
                     else:
-                        print "setting", all[i].strip(), "True"
+                        print("setting", all[i].strip(), "True")
                         OptDB.setValue(all[i].strip('-'),True)
                         i=i+1
                 else:
-                    print "setting", all[i].strip(), "True"
+                    print("setting", all[i].strip(), "True")
                     OptDB.setValue(all[i].strip('-'),True)
                     i=i+1
         so.tnList=[0.0,0.001,0.011]            

--- a/Tests/2nd_set/test_sluice_gate.py
+++ b/Tests/2nd_set/test_sluice_gate.py
@@ -87,15 +87,15 @@ class TestSluiceGateTetgen(TestTools.AirWaterVVTest):
             while i < len(all):
                 if i < len(all)-1:
                     if all[i+1][0]!='-':
-                        print "setting ", all[i].strip(), all[i+1]
+                        print("setting ", all[i].strip(), all[i+1])
                         OptDB.setValue(all[i].strip('-'),all[i+1])
                         i=i+2
                     else:
-                        print "setting ", all[i].strip(), "True"
+                        print("setting ", all[i].strip(), "True")
                         OptDB.setValue(all[i].strip('-'),True)
                         i=i+1
                 else:
-                    print "setting ", all[i].strip(), "True"
+                    print("setting ", all[i].strip(), "True")
                     OptDB.setValue(all[i].strip('-'),True)
                     i=i+1
         so.tnList=[0.0,0.001,0.011]            

--- a/Tests/2nd_set/test_standingWaves.py
+++ b/Tests/2nd_set/test_standingWaves.py
@@ -10,6 +10,7 @@ import collections as cll
 import csv
 import math
 from proteus.test_utils import TestTools
+import subprocess
 
 from proteus.defaults import (load_physics as load_p,
                               load_numerics as load_n,
@@ -64,47 +65,49 @@ class TestStandingWavesTetgen(TestTools.AirWaterVVTest):
 
             
     def test_run(self):
-        from petsc4py import PETSc
-        pList = []
-        nList = []
-        so = load_so('standing_waves_so',modulepath)
-        for (p,n) in so.pnList:
-            pList.append(load_p(p,modulepath))
-            nList.append(load_n(n,modulepath))
-            if pList[-1].name == None:
-                pList[-1].name = p
-        #so = standing_waves_so
-        so.name = "standing_waves"
-        if so.sList == []:
-            for i in range(len(so.pnList)):
-                s = default_s
-                so.sList.append(s)
-        Profiling.logLevel=7
-        Profiling.verbose=True
-        # PETSc solver configuration
-        OptDB = PETSc.Options()
-        with open(petsc_options) as f:
-            all = f.read().split()
-            i=0
-            while i < len(all):
-                if i < len(all)-1:
-                    if all[i+1][0]!='-':
-                        print "setting ", all[i].strip(), all[i+1]
-                        OptDB.setValue(all[i].strip('-'),all[i+1])
-                        i=i+2
-                    else:
-                        print "setting ", all[i].strip(), "True"
-                        OptDB.setValue(all[i].strip('-'),True)
-                        i=i+1
-                else:
-                    print "setting ", all[i].strip(), "True"
-                    OptDB.setValue(all[i].strip('-'),True)
-                    i=i+1
-        so.tnList=[0.0,0.001,0.011]            
-        #so.tnList=[0.0,0.001]+[0.001 + i*0.01 for i in range(1,int(round(0.03/0.01))+1)]            
-        ns = NumericalSolution.NS_base(so,pList,nList,so.sList,opts)
-        ns.calculateSolution('standing_waves')
-        
+        #from petsc4py import PETSc
+        #pList = []
+        #nList = []
+        #so = load_so('standing_waves_so',modulepath)
+        #for (p,n) in so.pnList:
+        #    pList.append(load_p(p,modulepath))
+        #    nList.append(load_n(n,modulepath))
+        #    if pList[-1].name == None:
+        #        pList[-1].name = p
+        ##so = standing_waves_so
+        #so.name = "standing_waves"
+        #if so.sList == []:
+        #    for i in range(len(so.pnList)):
+        #        s = default_s
+        #        so.sList.append(s)
+        #Profiling.logLevel=7
+        #Profiling.verbose=True
+        ## PETSc solver configuration
+        #OptDB = PETSc.Options()
+        #with open(petsc_options) as f:
+        #    all = f.read().split()
+        #    i=0
+        #    while i < len(all):
+        #        if i < len(all)-1:
+        #            if all[i+1][0]!='-':
+        #                print "setting ", all[i].strip(), all[i+1]
+        #                OptDB.setValue(all[i].strip('-'),all[i+1])
+        #                i=i+2
+        #            else:
+        #                print "setting ", all[i].strip(), "True"
+        #                OptDB.setValue(all[i].strip('-'),True)
+        #                i=i+1
+        #        else:
+        #            print "setting ", all[i].strip(), "True"
+        #            OptDB.setValue(all[i].strip('-'),True)
+        #            i=i+1
+        #so.tnList=[0.0,0.001,0.011]            
+        ##so.tnList=[0.0,0.001]+[0.001 + i*0.01 for i in range(1,int(round(0.03/0.01))+1)]            
+        #ns = NumericalSolution.NS_base(so,pList,nList,so.sList,opts)
+        #ns.calculateSolution('standing_waves')
+        runCommand = "parun --TwoPhaseFlow --path " +modulepath+" -C \"Tend=0.011 refinement=2 cfl=0.9\" standing_waves.py"
+        subprocess.check_call(runCommand,shell=True)
+      
         
         standing_log = NumericResults.create_log('proteus.log')
 

--- a/Tests/2nd_set/test_wavesloshing.py
+++ b/Tests/2nd_set/test_wavesloshing.py
@@ -11,6 +11,7 @@ import numpy as np
 import collections as cll
 import csv
 from proteus.test_utils import TestTools
+import subprocess
 
 from proteus.defaults import (load_physics as load_p,
                               load_numerics as load_n,
@@ -67,48 +68,49 @@ class TestWaveSloshingTetgen(TestTools.AirWaterVVTest):
 
             
     def test_run(self):
-        from petsc4py import PETSc
-        pList = []
-        nList = []
-        so = load_so('wavesloshing_so',modulepath)
-        for (p,n) in so.pnList:
-            pList.append(load_p(p,modulepath))
-            nList.append(load_n(n,modulepath))
-            if pList[-1].name == None:
-                pList[-1].name = p
-        #so = wavesloshing_so
-        so.name = "wavesloshing"
-        if so.sList == []:
-            for i in range(len(so.pnList)):
-                s = default_s
-                so.sList.append(s)
-        Profiling.logLevel=7
-        Profiling.verbose=True
-        # PETSc solver configuration
-        OptDB = PETSc.Options()
-        with open(petsc_options) as f:
-            all = f.read().split()
-            i=0
-            while i < len(all):
-                if i < len(all)-1:
-                    if all[i+1][0]!='-':
-                        print "setting ", all[i].strip(), all[i+1]
-                        OptDB.setValue(all[i].strip('-'),all[i+1])
-                        i=i+2
-                    else:
-                        print "setting ", all[i].strip(), "True"
-                        OptDB.setValue(all[i].strip('-'),True)
-                        i=i+1
-                else:
-                    print "setting ", all[i].strip(), "True"
-                    OptDB.setValue(all[i].strip('-'),True)
-                    i=i+1
-        so.tnList=[0.0,0.001,0.011]            
-        #so.tnList=[0.0,0.001]+[0.001 + i*0.01 for i in range(1,int(round(0.03/0.01))+1)]            
-        ns = NumericalSolution.NS_base(so,pList,nList,so.sList,opts)
-        ns.calculateSolution('wavesloshing')
+        #from petsc4py import PETSc
+        #pList = []
+        #nList = []
+        #so = load_so('wavesloshing_so',modulepath)
+        #for (p,n) in so.pnList:
+        #    pList.append(load_p(p,modulepath))
+        #    nList.append(load_n(n,modulepath))
+        #    if pList[-1].name == None:
+        #        pList[-1].name = p
+        ##so = wavesloshing_so
+        #so.name = "wavesloshing"
+        #if so.sList == []:
+        #    for i in range(len(so.pnList)):
+        #        s = default_s
+        #        so.sList.append(s)
+        #Profiling.logLevel=7
+        #Profiling.verbose=True
+        ## PETSc solver configuration
+        #OptDB = PETSc.Options()
+        #with open(petsc_options) as f:
+        #    all = f.read().split()
+        #    i=0
+        #    while i < len(all):
+        #        if i < len(all)-1:
+        #            if all[i+1][0]!='-':
+        #                print "setting ", all[i].strip(), all[i+1]
+        #                OptDB.setValue(all[i].strip('-'),all[i+1])
+        #                i=i+2
+        #            else:
+        #                print "setting ", all[i].strip(), "True"
+        #                OptDB.setValue(all[i].strip('-'),True)
+        #                i=i+1
+        #        else:
+        #            print "setting ", all[i].strip(), "True"
+        #            OptDB.setValue(all[i].strip('-'),True)
+        #            i=i+1
+        #so.tnList=[0.0,0.001,0.011]            
+        ##so.tnList=[0.0,0.001]+[0.001 + i*0.01 for i in range(1,int(round(0.03/0.01))+1)]            
+        #ns = NumericalSolution.NS_base(so,pList,nList,so.sList,opts)
+        #ns.calculateSolution('wavesloshing')
+        runCommand = "parun --TwoPhaseFlow --path " +modulepath+" -C \"T=0.011 he=0.01\" wavesloshing.py"
+        subprocess.check_call(runCommand,shell=True)
 
-        
         sloshing_log = NumericResults.create_log('proteus.log')
 
         text = sloshing_log.read()


### PR DESCRIPTION
PR to fix syntax in air-water-vv tests after migration to python3 and transition of cases to using TwoPhaseFlow app. 

The tests are largely syntax/integration tests with no reference value for comparison.

This replaces #232 (forgot that was started).